### PR TITLE
[CONTROLLER-RECORDER]fix dup data error

### DIFF
--- a/server/controller/recorder/db/operator_test.go
+++ b/server/controller/recorder/db/operator_test.go
@@ -28,6 +28,7 @@ func (t *SuiteTest) TestformatDBItemsToAdd() {
 	vifs := []*mysql.VInterface{newDBVInterface(), newDBVInterface()}
 	vif1 := vifs[0]
 	vif2 := vifs[1]
+	vifs = append(vifs, vifs[1])
 	mysql.Db.Create(&vif1)
 
 	vifsToAdd, lcuuidsToAdd, ok := operator.formatDBItemsToAdd(vifs)


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

- if cloud gives dup data, recorder will insert directly because batch operation is supported and no validation for cloud dup

**Impactions**

**Test method**

- UT

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)