### PR TITLE
[controller] fix default k8s domain port_name_regex value

### DIFF
--- a/server/controller/common/const.go
+++ b/server/controller/common/const.go
@@ -159,7 +159,7 @@ const (
 
 const (
 	DEFAULT_ENCRYPTION_PASSWORD = "******"
-	DEFAULT_PORT_NAME_REGEX     = "(cni|flannel|vxlan.calico|tunl)"
+	DEFAULT_PORT_NAME_REGEX     = "(cni|flannel|vxlan.calico|tunl|en[ospx])"
 
 	OPENSTACK         = 1
 	VSPHERE           = 2


### PR DESCRIPTION
**Phenomenon and reproduction steps**

**Root cause and solution**

**Impactions**

**Test method**

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)