### PR TITLE
[AGENT] Pass in agent identifier in main.rs

### DIFF
--- a/agent/src/main.rs
+++ b/agent/src/main.rs
@@ -74,7 +74,8 @@ fn main() -> Result<()> {
         println!(env!("RUSTC_VERSION"));
         return Ok(());
     }
-    let mut t = trident::Trident::start(&Path::new(&opts.config_file), version)?;
+    let mut t =
+        trident::Trident::start(&Path::new(&opts.config_file), env!("AGENT_NAME"), version)?;
     wait_on_signals();
     t.stop();
 

--- a/agent/src/rpc/synchronizer.rs
+++ b/agent/src/rpc/synchronizer.rs
@@ -15,7 +15,6 @@
  */
 
 use std::collections::HashMap;
-use std::env;
 use std::fs::{self, File};
 use std::io::{BufWriter, Write};
 use std::mem;
@@ -64,6 +63,7 @@ const SECOND: Duration = Duration::from_secs(1);
 const NORMAL_EXIT_WITH_RESTART: i32 = 3;
 
 pub struct StaticConfig {
+    pub agent_ident: &'static str,
     pub revision: &'static str,
     pub boot_time: SystemTime,
 
@@ -79,6 +79,7 @@ pub struct StaticConfig {
 impl Default for StaticConfig {
     fn default() -> Self {
         Self {
+            agent_ident: "",
             revision: "",
             boot_time: SystemTime::now(),
             tap_mode: Default::default(),
@@ -392,6 +393,7 @@ impl Synchronizer {
     pub fn new(
         session: Arc<Session>,
         trident_state: TridentState,
+        agent_ident: &'static str,
         revision: &'static str,
         ctrl_ip: String,
         ctrl_mac: String,
@@ -403,6 +405,7 @@ impl Synchronizer {
     ) -> Synchronizer {
         Synchronizer {
             static_config: Arc::new(StaticConfig {
+                agent_ident,
                 revision,
                 boot_time: SystemTime::now(),
                 tap_mode: tp::TapMode::Local,
@@ -486,7 +489,7 @@ impl Synchronizer {
             state: Some(tp::State::Running.into()),
             revision: Some(static_config.revision.to_owned()),
             exception: Some(exception_handler.take()),
-            process_name: Some(env!("AGENT_NAME").into()),
+            process_name: Some(static_config.agent_ident.to_owned()),
             ctrl_mac: Some(running_config.ctrl_mac.clone()),
             ctrl_ip: Some(running_config.ctrl_ip.clone()),
             tap_mode: Some(static_config.tap_mode.into()),

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -110,7 +110,11 @@ pub const DEFAULT_TRIDENT_CONF_FILE: &'static str = "/etc/trident.yaml";
 pub const DEFAULT_TRIDENT_CONF_FILE: &'static str = "C:\\DeepFlow\\trident\\trident-windows.yaml";
 
 impl Trident {
-    pub fn start<P: AsRef<Path>>(config_path: P, revision: &'static str) -> Result<Trident> {
+    pub fn start<P: AsRef<Path>>(
+        config_path: P,
+        agent_ident: &'static str,
+        revision: &'static str,
+    ) -> Result<Trident> {
         let state = Arc::new((Mutex::new(State::Running), Condvar::new()));
         let state_thread = state.clone();
 
@@ -179,6 +183,7 @@ impl Trident {
             if let Err(e) = Self::run(
                 state_thread,
                 config,
+                agent_ident,
                 revision,
                 logger_handle,
                 remote_log_config,
@@ -195,6 +200,7 @@ impl Trident {
     fn run(
         state: TridentState,
         mut config: Config,
+        agent_ident: &'static str,
         revision: &'static str,
         logger_handle: LoggerHandle,
         remote_log_config: RemoteLogConfig,
@@ -248,7 +254,8 @@ impl Trident {
         let synchronizer = Arc::new(Synchronizer::new(
             session.clone(),
             state.clone(),
-            revision.clone(),
+            agent_ident,
+            revision,
             ctrl_ip.to_string(),
             ctrl_mac.to_string(),
             config_handler.static_config.controller_ips[0].clone(),


### PR DESCRIPTION
**Phenomenon and reproduction steps**

Projects depending on deepflow-agent can't use build.rs to set agent name

**Root cause and solution**

Build.rs in dependency replaces AGENT_NAME

**Impactions**

N/A

**Test method**

N/A

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)