### PR TITLE
[AGENT] Boxing queue entries to reduce memory

### DIFF
--- a/agent/Cargo.lock
+++ b/agent/Cargo.lock
@@ -359,24 +359,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
-dependencies = [
- "cfg-if",
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -404,16 +390,6 @@ dependencies = [
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b10ddc024425c88c2ad148c1b0fd53f4c6d38db9697c9f1588381212fa657c9"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -538,7 +514,6 @@ dependencies = [
  "chrono",
  "clap 3.2.8",
  "criterion",
- "crossbeam",
  "dashmap 5.3.3",
  "dns-lookup",
  "dunce",

--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -19,7 +19,6 @@ cadence = "0.27.0"
 cgroups-rs = "0.2.9"
 chrono = "0.4.19"
 clap = { version = "3.2.8", features = ["derive"] }
-crossbeam = "0.8.1"
 dashmap = "5.3.3"
 dns-lookup = "1.0.8"
 enum_dispatch = "0.3.7"

--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -711,7 +711,7 @@ impl Stash {
             .map(|(_, mut doc)| {
                 doc.timestamp = self.start_time.as_secs() as u32;
                 doc.flags |= self.doc_flag;
-                SendItem::Metrics(doc)
+                SendItem::Metrics(Box::new(doc))
             })
             .collect::<Vec<_>>();
         let mut index = 0;
@@ -744,7 +744,7 @@ pub struct Collector {
     counter: Arc<CollectorCounter>,
     running: Arc<AtomicBool>,
     thread: Mutex<Option<JoinHandle<()>>>,
-    receiver: Arc<Receiver<AccumulatedFlow>>,
+    receiver: Arc<Receiver<Box<AccumulatedFlow>>>,
     sender: DebugSender<SendItem>,
 
     context: Context,
@@ -753,7 +753,7 @@ pub struct Collector {
 impl Collector {
     pub fn new(
         id: u32,
-        receiver: Receiver<AccumulatedFlow>,
+        receiver: Receiver<Box<AccumulatedFlow>>,
         sender: DebugSender<SendItem>,
         metric_type: MetricsType,
         delay_seconds: u32,
@@ -820,7 +820,7 @@ impl Collector {
                     Ok(acc_flows) => {
                         for flow in acc_flows {
                             let time_in_second = flow.tagged_flow.flow.flow_stat_time.as_secs();
-                            stash.collect(Some(flow), time_in_second);
+                            stash.collect(Some(*flow), time_in_second);
                         }
                     }
                     Err(Error::Timeout) => {

--- a/agent/src/collector/flow_aggr.rs
+++ b/agent/src/collector/flow_aggr.rs
@@ -341,12 +341,12 @@ impl ThrottlingQueue {
 
         self.period_count += 1;
         if self.stashs.len() < self.throttle as usize {
-            self.stashs.push(SendItem::L4FlowLog(f));
+            self.stashs.push(SendItem::L4FlowLog(Box::new(f)));
             true
         } else {
             let r = self.small_rng.gen_range(0..self.period_count);
             if r < self.throttle as usize {
-                self.stashs[r] = SendItem::L4FlowLog(f);
+                self.stashs[r] = SendItem::L4FlowLog(Box::new(f));
             }
             false
         }

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -85,8 +85,8 @@ pub(super) struct BaseDispatcher {
 
     pub(super) analyzer_dedup_disabled: bool,
 
-    pub(super) flow_output_queue: DebugSender<TaggedFlow>,
-    pub(super) log_output_queue: DebugSender<MetaAppProto>,
+    pub(super) flow_output_queue: DebugSender<Box<TaggedFlow>>,
+    pub(super) log_output_queue: DebugSender<Box<MetaAppProto>>,
 
     pub(super) counter: Arc<PacketCounter>,
     pub(super) terminated: Arc<AtomicBool>,

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -306,8 +306,8 @@ pub struct DispatcherBuilder {
     tap_typer: Option<Arc<TapTyper>>,
     analyzer_dedup_disabled: Option<bool>,
     libvirt_xml_extractor: Option<Arc<LibvirtXmlExtractor>>,
-    flow_output_queue: Option<DebugSender<TaggedFlow>>,
-    log_output_queue: Option<DebugSender<MetaAppProto>>,
+    flow_output_queue: Option<DebugSender<Box<TaggedFlow>>>,
+    log_output_queue: Option<DebugSender<Box<MetaAppProto>>>,
     packet_sequence_output_queue:
         Option<DebugSender<Box<packet_sequence_block::PacketSequenceBlock>>>, // Enterprise Edition Feature: packet-sequence
     stats_collector: Option<Arc<Collector>>,
@@ -378,12 +378,12 @@ impl DispatcherBuilder {
         self
     }
 
-    pub fn flow_output_queue(mut self, v: DebugSender<TaggedFlow>) -> Self {
+    pub fn flow_output_queue(mut self, v: DebugSender<Box<TaggedFlow>>) -> Self {
         self.flow_output_queue = Some(v);
         self
     }
 
-    pub fn log_output_queue(mut self, v: DebugSender<MetaAppProto>) -> Self {
+    pub fn log_output_queue(mut self, v: DebugSender<Box<MetaAppProto>>) -> Self {
         self.log_output_queue = Some(v);
         self
     }

--- a/agent/src/pcap/mod.rs
+++ b/agent/src/pcap/mod.rs
@@ -54,7 +54,7 @@ pub struct Packet {
 
 #[derive(Debug)]
 pub enum PcapPacket {
-    Packet(Packet),
+    Packet(Box<Packet>),
     Terminated,
 }
 

--- a/agent/src/pcap/worker.rs
+++ b/agent/src/pcap/worker.rs
@@ -127,7 +127,7 @@ impl Worker {
         // 上层Sender要关闭channel，才调用worker的stop方法
         let thread = thread::spawn(move || loop {
             match packet_receiver.recv(Some(interval)) {
-                Ok(PcapPacket::Packet(pkt)) => Self::write_pkt(pkt, &writers, &config, &counter),
+                Ok(PcapPacket::Packet(pkt)) => Self::write_pkt(*pkt, &writers, &config, &counter),
                 Err(Error::Timeout) => {
                     let now = get_timestamp(ntp_diff.load(Ordering::Relaxed));
                     Self::clean_timeout_file(now, &writers, &config, &counter);

--- a/agent/src/sender/mod.rs
+++ b/agent/src/sender/mod.rs
@@ -44,9 +44,9 @@ const PRE_FILE_SUFFIX: &str = ".pre";
 const MAX_FILE_SIZE: usize = 1_000_000_000;
 
 pub enum SendItem {
-    L4FlowLog(TaggedFlow),
-    L7FlowLog(AppProtoLogsData),
-    Metrics(Document),
+    L4FlowLog(Box<TaggedFlow>),
+    L7FlowLog(Box<AppProtoLogsData>),
+    Metrics(Box<Document>),
     ExternalOtel(OpenTelemetry),
     ExternalProm(PrometheusMetric),
     ExternalTelegraf(TelegrafMetric),

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -1142,7 +1142,7 @@ impl Components {
     fn new_collector(
         id: usize,
         stats_collector: &Arc<stats::Collector>,
-        flow_receiver: queue::Receiver<TaggedFlow>,
+        flow_receiver: queue::Receiver<Box<TaggedFlow>>,
         l4_flow_aggr_sender: Option<queue::DebugSender<SendItem>>,
         metrics_sender: queue::DebugSender<SendItem>,
         metrics_type: MetricsType,


### PR DESCRIPTION
**Phenomenon and reproduction steps**

Large amout of memory allocated by queues

**Root cause and solution**

Queue allocates size_of<T>() * len memory.
Use Box when size of T is large

**Impactions**

N/A

**Test method**

Check memory

**Affected branch(es)**

* main

**Checklist**

- [ ] Dependencies update required
- [ ] Common bug (similar problem in other repo)