### PR TITLE
[ingester] fix flow tag data drops

### DIFF
--- a/server/ingester/ext_metrics/dbwriter/ext_metrics_writer.go
+++ b/server/ingester/ext_metrics/dbwriter/ext_metrics_writer.go
@@ -213,7 +213,14 @@ func NewExtMetricsWriter(
 	msgType datatype.MessageType,
 	db string,
 	config *config.Config) (*ExtMetricsWriter, error) {
-	flowTagWriter, err := flow_tag.NewFlowTagWriter(msgType.String(), db, config.TTL, DefaultPartition, config.Base, &config.CKWriterConfig)
+	// one row of ext_metrics will generate multiple rows of flow_tag, so the writer queue of flow tag needs to be longer.
+	flowTagWriterConfig := baseconfig.CKWriterConfig{
+		QueueCount:   config.CKWriterConfig.QueueCount,
+		QueueSize:    config.CKWriterConfig.QueueSize * 10,
+		BatchSize:    config.CKWriterConfig.BatchSize * 10,
+		FlushTimeout: config.CKWriterConfig.FlushTimeout,
+	}
+	flowTagWriter, err := flow_tag.NewFlowTagWriter(msgType.String(), db, config.TTL, DefaultPartition, config.Base, &flowTagWriterConfig)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
For one row of ext_metrics data will generate multiple rows of flow_tag data,
so the writer queue of flow tag needs to be longer.

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

### Fixes flow tag data drops a lot
#### Steps to reproduce the bug
- receive prometheus datas
- check Infludb table profile."deepflow_server.ingester.queue"  overwritten field > 0  
#### Changes to fix the bug
- set flow_tag writer queue size 10 times as ext_metrics queue size.
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
