### PR TITLE
[ingester] fix set datasource failed

### DIFF
--- a/server/ingester/datasource/handle.go
+++ b/server/ingester/datasource/handle.go
@@ -457,7 +457,6 @@ func (m *DatasourceManager) Handle(dbGroup, action, baseTable, dstTable, aggrSum
 				Username: m.user,
 				Password: m.password,
 			},
-			Settings: map[string]interface{}{"read_timeout": m.readTimeout},
 		})
 
 		if err != nil {


### PR DESCRIPTION
the clickhouse dirver not support 'read_timeout' parameter

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

### 修复数据源设置失败
#### Steps to reproduce the bug
- add/mod/remove datasource failed
#### Changes to fix the bug
-  clickhouse driver not support 'read_timeout' parameter, so remove it
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
