### PR TITLE
[AGENT] FIX Qg lost layer7 metrics

### DIFF
--- a/agent/src/collector/acc_flow.rs
+++ b/agent/src/collector/acc_flow.rs
@@ -33,7 +33,7 @@ pub struct AccumulatedFlow {
 
     pub policy_ids: [U16Set; 2],
     pub flow_meter: FlowMeter,
-    pub app_meter: Option<AppMeter>,
+    pub app_meter: AppMeter,
     pub key: QgKey,
     pub time_in_second: Duration,
     pub nat_src_ip: IpAddr,
@@ -61,7 +61,7 @@ impl AccumulatedFlow {
         &mut self,
         time_in_second: Duration,
         flow_meter: &FlowMeter,
-        app_meter: Option<&AppMeter>,
+        app_meter: &AppMeter,
         policy_ids: &[U16Set; 2],
         tagged_flow: &Arc<TaggedFlow>,
     ) {
@@ -79,17 +79,9 @@ impl AccumulatedFlow {
                     && other_stats.l7_protocol != L7Protocol::Unknown)
             {
                 self.l7_protocol = other_stats.l7_protocol;
-                if let Some((self_meter, other_meter)) = self.app_meter.as_mut().zip(app_meter) {
-                    *self_meter = *other_meter;
-                } else if let Some(other_meter) = app_meter {
-                    self.app_meter = Some(*other_meter);
-                }
+                self.app_meter = *app_meter;
             } else if other_stats.l7_protocol == self.l7_protocol {
-                if let Some((self_meter, other_meter)) = self.app_meter.as_mut().zip(app_meter) {
-                    self_meter.sequential_merge(other_meter);
-                } else if let Some(other_meter) = app_meter {
-                    self.app_meter = Some(*other_meter);
-                }
+                self.app_meter.sequential_merge(app_meter);
             }
         }
     }

--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -575,11 +575,9 @@ impl Stash {
             if tagger.l7_protocol != L7Protocol::Unknown
                 && self.context.config.load().l7_metrics_enabled
             {
-                if let Some(app_meter) = acc_flow.app_meter.as_ref() {
-                    tagger.code |= Code::L7_PROTOCOL;
-                    let key = StashKey::new(&tagger, ip, None);
-                    self.add(key, tagger, Meter::App(app_meter.clone()));
-                }
+                tagger.code |= Code::L7_PROTOCOL;
+                let key = StashKey::new(&tagger, ip, None);
+                self.add(key, tagger, Meter::App(acc_flow.app_meter.clone()));
             }
         }
     }
@@ -697,11 +695,9 @@ impl Stash {
         if tagger.l7_protocol != L7Protocol::Unknown
             && self.context.config.load().l7_metrics_enabled
         {
-            if let Some(app_meter) = acc_flow.app_meter.as_ref() {
-                tagger.code |= Code::L7_PROTOCOL;
-                let key = StashKey::new(&tagger, src_ip, Some(dst_ip));
-                self.add(key, tagger, Meter::App(app_meter.clone()));
-            }
+            tagger.code |= Code::L7_PROTOCOL;
+            let key = StashKey::new(&tagger, src_ip, Some(dst_ip));
+            self.add(key, tagger, Meter::App(acc_flow.app_meter.clone()));
         }
     }
 


### PR DESCRIPTION
The initialization of appMeter is unreasonable, resulting in it being none and unable to insert L7 metrics

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Agent

### Fixes 

#### Steps to reproduce the bug
- The initialization of appMeter is unreasonable, resulting in it being none and unable to insert L7 metrics

#### Changes to fix the bug
-  Properly initialize appMeter and control writing to Layer7 metrics through the L7metricsEnabled switch

#### Affected branches
- main



<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
