### PR TITLE
[server] fix initializing log level probability causes crash

### DIFF
--- a/server/controller/controller/controller.go
+++ b/server/controller/controller/controller.go
@@ -62,9 +62,6 @@ func Start(configPath string) {
 	serverCfg := config.DefaultConfig()
 	serverCfg.Load(configPath)
 	cfg := &serverCfg.ControllerConfig
-	logger.EnableFileLog(cfg.LogFile)
-	logLevel, _ := logging.LogLevel(cfg.LogLevel)
-	logging.SetLevel(logLevel, "")
 	bytes, _ := yaml.Marshal(cfg)
 	log.Info("============================== Launching YUNSHAN DeepFlow Controller ==============================")
 	log.Infof("controller config:\n%s", string(bytes))

--- a/server/ingester/config/config.go
+++ b/server/ingester/config/config.go
@@ -174,7 +174,7 @@ func Load(path string) *Config {
 			StreamRozeEnabled: true,
 			UDPReadBuffer:     64 << 20,
 			TCPReadBuffer:     4 << 20,
-			LogFile:           "/var/log/ingester/ingester.log",
+			LogFile:           "/var/log/deepflow/server.log",
 			CKDiskMonitor:     CKDiskMonitor{DefaultCheckInterval, DefaultDiskUsedPercent, DefaultDiskFreeSpace},
 			CKS3Storage:       CKS3Storage{false, DefaultCKDBS3Volume, DefaultCKDBS3TTLTimes},
 			Influxdb:          HostPort{DefaultInfluxdbHost, DefaultInfluxdbPort},

--- a/server/ingester/ingester/ingester.go
+++ b/server/ingester/ingester/ingester.go
@@ -29,7 +29,6 @@ import (
 	"github.com/deepflowys/deepflow/server/ingester/datasource"
 	"github.com/deepflowys/deepflow/server/libs/datatype"
 	"github.com/deepflowys/deepflow/server/libs/debug"
-	"github.com/deepflowys/deepflow/server/libs/logger"
 	"github.com/deepflowys/deepflow/server/libs/pool"
 	"github.com/deepflowys/deepflow/server/libs/receiver"
 	"github.com/deepflowys/deepflow/server/libs/stats"
@@ -60,12 +59,7 @@ const (
 )
 
 func Start(configPath string) []io.Closer {
-	logger.EnableStdoutLog()
-
 	cfg := config.Load(configPath)
-	logger.EnableFileLog(cfg.LogFile)
-	logLevel, _ := logging.LogLevel(cfg.LogLevel)
-	logging.SetLevel(logLevel, "")
 	bytes, _ := yaml.Marshal(cfg)
 	log.Info("============================== Launching YUNSHAN DeepFlow Ingester ==============================")
 	log.Infof("ingester base config:\n%s", string(bytes))

--- a/server/querier/querier/querier.go
+++ b/server/querier/querier/querier.go
@@ -26,7 +26,6 @@ import (
 	logging "github.com/op/go-logging"
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/deepflowys/deepflow/server/libs/logger"
 	"github.com/deepflowys/deepflow/server/libs/stats"
 	"github.com/deepflowys/deepflow/server/querier/common"
 	"github.com/deepflowys/deepflow/server/querier/config"
@@ -41,9 +40,6 @@ func Start(configPath string) {
 	ServerCfg.Load(configPath)
 	config.Cfg = &ServerCfg.QuerierConfig
 	cfg := ServerCfg.QuerierConfig
-	logger.EnableFileLog(cfg.LogFile)
-	logLevel, _ := logging.LogLevel(cfg.LogLevel)
-	logging.SetLevel(logLevel, "")
 	bytes, _ := yaml.Marshal(cfg)
 	log.Info("============================== Launching YUNSHAN DeepFlow Querier ==============================")
 	log.Infof("querier config:\n%s", string(bytes))

--- a/server/server.yaml
+++ b/server/server.yaml
@@ -1,8 +1,9 @@
+# logfile path
+log-file: /var/log/deepflow/server.log
+# loglevel: "debug/info/warn/error"
+log-level: info
+
 controller:
-  # logfile path
-  log-file: /var/log/deepflow/server.log
-  # loglevel: "debug/info/warn/error"
-  log-level: info
   # controller http listenport
   listen-port: 20417
 
@@ -141,10 +142,6 @@ controller:
     exclude_ip_ranges:
 
 querier:
-  # logfile path
-  log-file: /var/log/deepflow/server.log
-  # loglevel: "debug/info/warn/error"
-  log-level: info
   # querier http listenport
   listen-port: 20416
 
@@ -247,12 +244,6 @@ ingester:
 
   ## syslog是否写入elasticsearch，默认启用
   #es-syslog: true
-
-  ## logfile path
-  #log-file: /var/log/ingester/ingester.log
-
-  ## loglevel: "debug/info/warn/error"
-  #log-level: info
 
   ## profiler
   #profiler: false


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server


### Fixes initializing log level probability causes crash
#### Steps to reproduce the bug
- restart deepflow-server
#### Changes to fix the bug
- only SetLevel one times
- SetLevet is map write, multi-threaded processing of writing map will cause crash
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
