### PR TITLE
[server/libs] support stats set process name joiner

### DIFF
--- a/server/libs/stats/interface.go
+++ b/server/libs/stats/interface.go
@@ -83,6 +83,10 @@ func SetProcessName(name string) {
 	setProcessName(name)
 }
 
+func SetProcessNameJoiner(joiner string) {
+	setProcessNameJoiner(joiner)
+}
+
 func RegisterPreHook(hook func()) {
 	lock.Lock()
 	preHooks = append(preHooks, hook)

--- a/server/libs/stats/stats.go
+++ b/server/libs/stats/stats.go
@@ -60,15 +60,16 @@ func (s *StatSource) String() string {
 }
 
 var (
-	processName string
-	hostname    string
-	lock        sync.Mutex
-	preHooks    []func()
-	statSources = LinkedList{}
-	remotes     = []string{}
-	dfRemote    string
-	remoteIndex = -1
-	connection  client.Client
+	processName       string
+	processNameJoiner string = "."
+	hostname          string
+	lock              sync.Mutex
+	preHooks          []func()
+	statSources       = LinkedList{}
+	remotes           = []string{}
+	dfRemote          string
+	remoteIndex       = -1
+	connection        client.Client
 
 	statsdClients  = make([]*statsd.Client, 2) // could be nil
 	dfstatsdClient *UDPClient                  // could be nil
@@ -168,7 +169,7 @@ func collectBatchPoints() client.BatchPoints {
 		statSource.skip = int(max(statSource.interval, MinInterval) / TICK_CYCLE)
 
 		fields := counterToFields(statSource.countable.GetCounter())
-		point, _ := client.NewPoint(processName+"."+statSource.modulePrefix+statSource.module, statSource.tags, fields, timestamp)
+		point, _ := client.NewPoint(processName+processNameJoiner+statSource.modulePrefix+statSource.module, statSource.tags, fields, timestamp)
 		bp.AddPoint(point)
 	}
 	lock.Unlock()
@@ -373,6 +374,11 @@ func setHostname(name string) {
 func setProcessName(name string) {
 	log.Info("Process name changed to", name)
 	processName = name
+}
+
+func setProcessNameJoiner(joiner string) {
+	log.Info("Process name joiner changed to", joiner)
+	processNameJoiner = joiner
 }
 
 func winBase(path string) string {


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Libs


### support stats set process name joiner
#### Steps to reproduce the bug
-  deepflow_agent stats alwarys send stats with "_" joiner
-  trident send stats  to clickhouse use  "." joiner default
- so  in clickhouse deepflow_agent/trident stats not in the same table.
#### Changes to fix the bug
-  add interface to set joiner,  trident will call the setter to set joiner as "_"
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
