### PR TITLE
[Agent] Fix ebpf flow aggregation error

### DIFF
--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -830,10 +830,10 @@ impl<'a> MetaPacket<'a> {
         return Ok(packet);
     }
 
-    pub fn ebpf_flow_id(&self) -> u64 {
-        let protocol = u8::from(self.l7_protocol_from_ebpf) as u64;
+    pub fn ebpf_flow_id(&self) -> u128 {
+        let protocol = u8::from(self.l7_protocol_from_ebpf) as u128;
 
-        self.socket_id | protocol << 56
+        (self.socket_id as u128) | protocol << u64::BITS
     }
 
     pub fn set_loopback_mac(&mut self, mac: MacAddr) {

--- a/agent/src/ebpf_collector/ebpf_collector.rs
+++ b/agent/src/ebpf_collector/ebpf_collector.rs
@@ -751,7 +751,7 @@ impl EbpfRunner {
             self.log_rate.clone(),
             self.output.clone(),
         );
-        let mut flow_map: LruCache<u64, FlowItem> = LruCache::new(Self::FLOW_MAP_SIZE);
+        let mut flow_map: LruCache<u128, FlowItem> = LruCache::new(Self::FLOW_MAP_SIZE);
 
         while unsafe { SWITCH } {
             let mut packet = self.receiver.recv(Some(Duration::from_millis(1)));


### PR DESCRIPTION
### This PR is for:
- Agent

### Fixes 
#### Steps to reproduce the bug
-  The key of the flow hash table uses 64 bits，and the key consists of socket_id and L7_Protocol composition，When the socket ID exceeds 56 bits, there may be an error in flow aggregation
#### Changes to fix the bug
-  The key of the flow hash table uses 128 bits

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
