### PR TITLE
[server] fix log level always is debug

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -81,6 +81,7 @@ func main() {
 	}
 
 	cfg := loadConfig(*configPath)
+	logger.EnableStdoutLog()
 	logger.EnableFileLog(cfg.LogFile)
 	logLevel, _ := logging.LogLevel(cfg.LogLevel)
 	logging.SetLevel(logLevel, "")

--- a/server/controller/controller/controller.go
+++ b/server/controller/controller/controller.go
@@ -22,8 +22,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/deepflowys/deepflow/server/libs/logger"
-
 	"github.com/gin-gonic/gin"
 	logging "github.com/op/go-logging"
 	yaml "gopkg.in/yaml.v2"
@@ -57,7 +55,6 @@ type Controller struct{}
 
 func Start(configPath string) {
 	flag.Parse()
-	logger.EnableStdoutLog()
 
 	serverCfg := config.DefaultConfig()
 	serverCfg.Load(configPath)


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- Server


### Fixes log level always is debug
#### Steps to reproduce the bug
- run, kubectl -n deepflow  logs deepflow-server deepflow-server
#### Changes to fix the bug
- enable log output
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
