### PR TITLE
[server/ingester] fix user defined datasoure read failed

### DIFF
--- a/server/ingester/ckissu/ckissu.go
+++ b/server/ingester/ckissu/ckissu.go
@@ -919,7 +919,7 @@ func (i *Issu) renameUserDefineDatasource(connect *sql.DB, ds *datasource.Dataso
 				OldDb:     dsInfo.db,
 				OldTables: []string{dsInfo.name + "_agg"},
 				NewDb:     ckdb.METRICS_DB,
-				NewTables: []string{fmt.Sprintf("%s.%s_%s", dsInfo.db, dsInfo.baseTable, dsInfo.name+"_agg")},
+				NewTables: []string{fmt.Sprintf("%s.%s", dsInfo.db, dsInfo.name+"_agg")},
 			}); err != nil {
 				return err
 			}

--- a/server/ingester/datasource/handle.go
+++ b/server/ingester/datasource/handle.go
@@ -212,13 +212,14 @@ const (
 
 func getMetricsTableName(id uint8, table string, t TableType) string {
 	tableId := zerodoc.MetricsTableID(id)
+	tablePrefix := strings.Split(tableId.TableName(), ".")[0]
 	if len(table) == 0 {
 		return fmt.Sprintf("%s.`%s_%s`", ckdb.METRICS_DB, tableId.TableName(), t.String())
 	}
 	if len(t.String()) == 0 {
-		return fmt.Sprintf("%s.`%s_%s`", ckdb.METRICS_DB, tableId.TableName(), table)
+		return fmt.Sprintf("%s.`%s.%s`", ckdb.METRICS_DB, tablePrefix, table)
 	}
-	return fmt.Sprintf("%s.`%s_%s_%s`", ckdb.METRICS_DB, tableId.TableName(), table, t.String())
+	return fmt.Sprintf("%s.`%s.%s_%s`", ckdb.METRICS_DB, tablePrefix, table, t.String())
 }
 
 func stringSliceHas(items []string, item string) bool {


### PR DESCRIPTION
for new datasource name should not add src table name prefix

<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:


- Server

### Fixes user defined datasource read failed
#### Steps to reproduce the bug
- create a datasource
- read the datasource
#### Changes to fix the bug
- datasource name should not add 1s/1m prefix
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
