### PR TITLE
[AGENT] Fix MQTT packet aggregation

### DIFF
--- a/agent/resources/test/flow_generator/mqtt/mqtt_connect.result
+++ b/agent/resources/test/flow_generator/mqtt/mqtt_connect.result
@@ -1,2 +1,2 @@
 MqttInfo { client_id: Some("test-1"), version: 4, pkt_type: Connect, req_msg_size: 41, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Connack, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
+MqttInfo { client_id: None, version: 4, pkt_type: Connack, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false

--- a/agent/resources/test/flow_generator/mqtt/mqtt_one_packet_multi_publish.result
+++ b/agent/resources/test/flow_generator/mqtt/mqtt_one_packet_multi_publish.result
@@ -1,20 +1,20 @@
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 17, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/0/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 18, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/1/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 19, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/2/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 20, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/3/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 21, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/4/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 22, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/5/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 23, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/6/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 24, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/7/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 25, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/8/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 26, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/9/world"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 17, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/0/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 18, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/1/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 19, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/2/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 20, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/3/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 21, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/4/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 22, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/5/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 23, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/6/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 24, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/7/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 25, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/8/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: true }, req_msg_size: 26, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("hello/9/world"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 0, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false

--- a/agent/resources/test/flow_generator/mqtt/mqtt_roundtrip.result
+++ b/agent/resources/test/flow_generator/mqtt/mqtt_roundtrip.result
@@ -1,18 +1,18 @@
 MqttInfo { client_id: Some("mqttx_eaf9a0c9"), version: 4, pkt_type: Connect, req_msg_size: 26, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Connack, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Subscribe, req_msg_size: 14, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "testtopic", qos: 0 }]), publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Suback, req_msg_size: -1, res_msg_size: 3, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Unsubscribe, req_msg_size: 13, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "testtopic", qos: -1 }]), publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Unsuback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Pingreq, req_msg_size: 0, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Pingresp, req_msg_size: -1, res_msg_size: 0, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Subscribe, req_msg_size: 47, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "yunshan", qos: 1 }, MqttTopic { name: "deepflow-agent", qos: 1 }, MqttTopic { name: "deepflow-server", qos: 1 }]), publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Suback, req_msg_size: -1, res_msg_size: 5, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: AtMostOnce, retain: false }, req_msg_size: -1, res_msg_size: 33, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: false }, req_msg_size: 35, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: ExactlyOnce, retain: false }, req_msg_size: 35, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Pubrec, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Pubrel, req_msg_size: 2, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Pubcomp, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
-MqttInfo { client_id: None, version: 4, pkt_type: Disconnect, req_msg_size: -1, res_msg_size: 0, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: true
+MqttInfo { client_id: None, version: 4, pkt_type: Connack, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Subscribe, req_msg_size: 14, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "testtopic", qos: 0 }]), publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Suback, req_msg_size: -1, res_msg_size: 3, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Unsubscribe, req_msg_size: 13, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "testtopic", qos: -1 }]), publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Unsuback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Pingreq, req_msg_size: 0, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Pingresp, req_msg_size: -1, res_msg_size: 0, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Subscribe, req_msg_size: 47, res_msg_size: -1, subscribe_topics: Some([MqttTopic { name: "yunshan", qos: 1 }, MqttTopic { name: "deepflow-agent", qos: 1 }, MqttTopic { name: "deepflow-server", qos: 1 }]), publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Suback, req_msg_size: -1, res_msg_size: 5, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: AtMostOnce, retain: false }, req_msg_size: -1, res_msg_size: 33, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: AtLeastOnce, retain: false }, req_msg_size: 35, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Puback, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Publish { dup: false, qos: ExactlyOnce, retain: false }, req_msg_size: 35, res_msg_size: -1, subscribe_topics: None, publish_topic: Some("deepflow-agent"), code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Pubrec, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Pubrel, req_msg_size: 2, res_msg_size: -1, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Pubcomp, req_msg_size: -1, res_msg_size: 2, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false
+MqttInfo { client_id: None, version: 4, pkt_type: Disconnect, req_msg_size: -1, res_msg_size: 0, subscribe_topics: None, publish_topic: None, code: 0 } is_mqtt: false

--- a/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-use std::{collections::HashMap, fmt, net::IpAddr};
+use std::{collections::HashMap, fmt};
 
 use log::{debug, warn};
 use nom::{
@@ -36,39 +36,6 @@ use crate::{
     flow_generator::error::{Error, Result},
     proto::flow_log::{self, MqttTopic},
 };
-
-// 因为有些包没有带客户端ID，然而客户端跟服务端是长连接，可以用四元组构造MQTT_ID去索引客户端ID
-// 四元组格式：(src_ip, dst_ip, src_port, dst_port)
-// =================
-// Because some packets do not have a client ID, but the client and the server
-// have a long connection, you can use a quadruple to construct MQTT_ID to index the client ID
-// quadruple：(src_ip, dst_ip, src_port, dst_port)
-pub fn generate_mqtt_id(src_addr: IpAddr, dst_addr: IpAddr, src_port: u16, dst_port: u16) -> u64 {
-    let ip_hash = {
-        let (src, dst) = match (src_addr, dst_addr) {
-            (IpAddr::V4(s), IpAddr::V4(d)) => (
-                u32::from_le_bytes(s.octets()),
-                u32::from_le_bytes(d.octets()),
-            ),
-            (IpAddr::V6(s), IpAddr::V6(d)) => {
-                let (src, dst) = (s.octets(), d.octets());
-                src.chunks(4)
-                    .zip(dst.chunks(4))
-                    .fold((0, 0), |(hash1, hash2), (b1, b2)| {
-                        (
-                            hash1 ^ u32::from_le_bytes(b1.try_into().unwrap()),
-                            hash2 ^ u32::from_le_bytes(b2.try_into().unwrap()),
-                        )
-                    })
-            }
-            _ => unreachable!(),
-        };
-        src ^ dst
-    };
-
-    let port_hash = (dst_port as u64) << 16 | src_port as u64;
-    (ip_hash as u64) << 32 | port_hash
-}
 
 #[derive(Clone, Debug)]
 pub struct MqttInfo {
@@ -153,13 +120,8 @@ impl MqttLog {
         mut special_info: AppProtoLogsInfo,
         base_info: AppProtoLogsBaseInfo,
     ) -> Result<AppProtoLogsData> {
-        let key = generate_mqtt_id(
-            base_info.ip_src,
-            base_info.ip_dst,
-            base_info.port_src,
-            base_info.port_dst,
-        );
         if let AppProtoLogsInfo::Mqtt(ref mut info) = special_info {
+            let key = base_info.flow_id;
             match info.pkt_type {
                 PacketKind::Connect => {
                     let client_id = info.client_id.as_ref().unwrap().clone();
@@ -383,7 +345,7 @@ pub fn mqtt_check_protocol(bitmap: &mut u128, packet: &MetaPacket) -> bool {
         return false;
     }
 
-    let mut payload = match packet.get_l4_payload() {
+    let payload = match packet.get_l4_payload() {
         Some(p) => p,
         None => return false,
     };

--- a/agent/src/flow_generator/protocol_logs/parser.rs
+++ b/agent/src/flow_generator/protocol_logs/parser.rs
@@ -31,8 +31,8 @@ use arc_swap::access::Access;
 use log::{debug, info, warn};
 
 use super::{
-    mqtt::generate_mqtt_id, AppProtoHead, AppProtoLogsBaseInfo, AppProtoLogsData, AppProtoLogsInfo,
-    DnsLog, DubboLog, KafkaLog, LogMessageType, MqttLog, MysqlLog, RedisLog,
+    AppProtoHead, AppProtoLogsBaseInfo, AppProtoLogsData, AppProtoLogsInfo, DnsLog, DubboLog,
+    KafkaLog, LogMessageType, MqttLog, MysqlLog, RedisLog,
 };
 use crate::{
     common::{
@@ -373,13 +373,7 @@ impl SessionQueue {
 
     fn calc_key(item: &AppProtoLogsData) -> u64 {
         if let AppProtoLogsInfo::Mqtt(_) = item.special_info {
-            let base_info = &item.base_info;
-            return generate_mqtt_id(
-                base_info.ip_src,
-                base_info.ip_dst,
-                base_info.port_src,
-                base_info.port_dst,
-            );
+            return item.base_info.flow_id;
         }
         let request_id = match &item.special_info {
             AppProtoLogsInfo::Dns(d) => d.trans_id as u32,


### PR DESCRIPTION
### This PR is for:

- Agent

### Reason:

Different statistical locations lead to different flowIDs, so it is impossible to distinguish mqtt flows according to the quadruple

### FIX:

Use flowId instead of quad to generate ID for aggregation



