### PR TITLE
[AGENT] fix K8S fetch resources deadlock

### DIFF
--- a/agent/Cargo.toml
+++ b/agent/Cargo.toml
@@ -53,7 +53,7 @@ signal-hook = "0.3"
 sysinfo = { version = "0.23", default-features = false }
 thiserror = "1.0"
 time = "0.3.9"
-tokio = { version = "1.12.0", features = ["full"] }
+tokio = { version = "1.20.1", features = ["full"] }
 tonic = "0.5.2"
 
 [target.'cfg(target_os = "linux")'.dependencies]


### PR DESCRIPTION
### This PR is for:

- Agent

### Issue:

Because synchronous Mutex is used, it is not applicable across multiple coroutines, resulting in deadlock

### FIX:

use async Mutex instead of sync Mutex

