### PR TITLE
[eBPF] Fix the buffer length calculation error in the case of iov

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1012,8 +1012,18 @@ static __inline void process_data(struct pt_regs *ctx, __u64 id,
 	if (!extra->vecs) {
 		infer_l7_class(conn_info, direction, args->buf, bytes_count, sock_state, extra);
 	} else {
-		struct iovec iov_cpy;
-		bpf_probe_read(&iov_cpy, sizeof(struct iovec), &args->iov[0]);
+		struct iovec iov_cpy = {};
+		int i;
+#pragma unroll
+		// In some cases length does not appear in iov[0],
+		// and now the loop is limited to 3 times
+		for (i = 0; i < 3; i++) {
+			if (iov_cpy.iov_len != 0 || i >= args->iovlen) {
+				break;
+			}
+			bpf_probe_read(&iov_cpy, sizeof(struct iovec),
+				       &args->iov[i]);
+		}
 		// Ensure we are not reading beyond the available data.
 		const size_t buf_size = iov_cpy.iov_len < bytes_count ? iov_cpy.iov_len : bytes_count;
 		infer_l7_class(conn_info, direction, iov_cpy.iov_base, buf_size, sock_state, extra);


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the buffer length calculation error in the case of iov
#### Steps to reproduce the bug

- emqtt_bench connects to the server

#### Changes to fix the bug

- Detect where lengths may appear

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
