### PR TITLE
[AGENT] fix mqtt protocol log merge method

### DIFF
--- a/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/mqtt.rs
@@ -90,15 +90,6 @@ impl Default for MqttInfo {
 impl MqttInfo {
     pub fn merge(&mut self, other: Self) {
         self.res_msg_size = other.res_msg_size;
-        match other.pkt_type {
-            PacketKind::Publish { .. } => {
-                self.publish_topic = other.publish_topic;
-            }
-            PacketKind::Unsubscribe | PacketKind::Subscribe => {
-                self.subscribe_topics = other.subscribe_topics;
-            }
-            _ => (),
-        }
     }
 }
 


### PR DESCRIPTION

### This PR is for:

- Agent

### Fixes no Publish message in the application log parsing

#### Changes to fix the bug
- retain MQTT Publish/Unsubscribe/Subscribe packet instead of merge

#### Affected branches
- main
#### Checklist
- [x] Added unit test to verify the fix.
  

