### PR TITLE
[eBPF] Fix HTTP2 uprobe COMM missing

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -188,10 +188,11 @@ static __inline void report_http2_header(struct pt_regs *ctx)
 static __inline void http2_fill_common_socket(struct http2_header_data *data,
 					      struct __socket_data *send_buffer)
 {
-	// source, coroutine_id, msg_type, timestamp
+	// source, coroutine_id, timestamp, comm
 	send_buffer->source = DATA_SOURCE_GO_HTTP2_UPROBE;
 	send_buffer->coroutine_id = get_current_goroutine();
 	send_buffer->timestamp = bpf_ktime_get_ns();
+	bpf_get_current_comm(send_buffer->comm, sizeof(send_buffer->comm));
 
 	// tcp_seq, direction
 	int tcp_seq;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes HTTP2 uprobe COMM missing
#### Steps to reproduce the bug

- Send Go HTTP2 message
- Check the COMM field

#### Changes to fix the bug

- Assign the COMM field

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
