### PR TITLE
[AGENT] adjust tokio::Runtime worker thread number

### DIFF
--- a/agent/src/config/config.rs
+++ b/agent/src/config/config.rs
@@ -25,7 +25,7 @@ use log::{error, info, warn};
 use md5::{Digest, Md5};
 use serde::Deserialize;
 use thiserror::Error;
-use tokio::runtime::Runtime;
+use tokio::runtime::Builder;
 
 use crate::common::decapsulate::TunnelType;
 use crate::common::{
@@ -126,7 +126,7 @@ impl Config {
                 }
             }
         };
-        let runtime = Runtime::new().unwrap();
+        let runtime = Builder::new_current_thread().enable_all().build().unwrap();
         runtime.block_on(async {
             loop {
                 session.update_current_server().await;

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -192,6 +192,7 @@ pub struct PlatformConfig {
     pub epc_id: u32,
     pub kubernetes_api_enabled: bool,
     pub namespace: Option<String>,
+    pub thread_threshold: u32,
 }
 
 #[derive(Clone, PartialEq, Debug, Eq)]
@@ -714,6 +715,7 @@ impl TryFrom<(Config, RuntimeConfig)> for ModuleConfig {
                 } else {
                     Some(conf.yaml_config.kubernetes_namespace.clone())
                 },
+                thread_threshold: conf.thread_threshold,
             },
             flow: (&conf).into(),
             log_parser: LogParserConfig {

--- a/agent/src/debug/rpc.rs
+++ b/agent/src/debug/rpc.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use bincode::{Decode, Encode};
 use parking_lot::RwLock;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 
 use super::error::{Error, Result};
 
@@ -72,7 +72,7 @@ impl RpcDebugger {
             status,
             config,
             running_config,
-            rt: Runtime::new().unwrap(),
+            rt: Builder::new_current_thread().enable_all().build().unwrap(),
         }
     }
 

--- a/agent/src/integration_collector.rs
+++ b/agent/src/integration_collector.rs
@@ -228,6 +228,7 @@ impl MetricServer {
         Self {
             running: Arc::new(AtomicBool::new(false)),
             rt: Builder::new_multi_thread()
+                .worker_threads(2)
                 .enable_all()
                 .thread_name("integration collector thread")
                 .build()

--- a/agent/src/platform/platform_synchronizer.rs
+++ b/agent/src/platform/platform_synchronizer.rs
@@ -28,7 +28,7 @@ use std::{
 use arc_swap::access::Access;
 use log::{debug, error, info, warn};
 use ring::digest;
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 
 use super::kubernetes::{
     check_read_link_ns, check_set_ns, ActivePoller, GenericPoller, PassivePoller, Poller,
@@ -552,7 +552,7 @@ impl PlatformSynchronizer {
     }
 
     fn process(args: ProcessArgs) {
-        let rt = Runtime::new().unwrap();
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
 
         let mut last_version = 0;
         let mut kubernetes_version = 0;

--- a/agent/src/rpc/synchronizer.rs
+++ b/agent/src/rpc/synchronizer.rs
@@ -36,7 +36,7 @@ use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use prost::Message;
 use rand::RngCore;
 use sysinfo::{System, SystemExt};
-use tokio::runtime::Runtime;
+use tokio::runtime::{Builder, Runtime};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::task::JoinHandle;
 use tokio::time;
@@ -429,7 +429,11 @@ impl Synchronizer {
             status: Default::default(),
             session,
             running: Arc::new(AtomicBool::new(false)),
-            rt: Runtime::new().unwrap(),
+            rt: Builder::new_multi_thread()
+                .worker_threads(1)
+                .enable_all()
+                .build()
+                .unwrap(),
             threads: Default::default(),
             flow_acl_listener: Arc::new(sync::Mutex::new(vec![Box::new(policy_setter)])),
             exception_handler,


### PR DESCRIPTION
### This PR is for:
- Agent

### Fixes the number of agent thread has exceed thread limit
#### Changes to fix the bug
- adjust tokio::Runtime worker thread number to make agent not exceed thread limit

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
   