### PR TITLE
[eBPF] Fix the problem that the tcp seq sequence number is 0

### DIFF
--- a/agent/build.rs
+++ b/agent/build.rs
@@ -86,7 +86,6 @@ fn set_linkage() -> Result<(), Box<dyn Error>> {
     println!("cargo:rustc-link-search=native=/usr/lib");
     println!("cargo:rustc-link-search=native=/usr/lib64");
 
-    println!("cargo:rustc-link-lib=static=GoReSym");
     println!("cargo:rustc-link-lib=static=bddisasm");
     println!("cargo:rustc-link-lib=static=dwarf");
     println!("cargo:rustc-link-lib=static=bcc_bpf");

--- a/agent/src/ebpf/kernel/go_tls_bpf.c
+++ b/agent/src/ebpf/kernel/go_tls_bpf.c
@@ -26,28 +26,6 @@ struct bpf_map_def SEC("maps") tls_conn_map = {
 	.max_entries = MAX_SYSTEM_THREADS,
 };
 
-struct http2_tcp_seq_key {
-	int tgid;
-	int fd;
-	__u32 tcp_seq_end;
-};
-
-/*
- * In uprobe_go_tls_read_exit()
- * Save the TCP sequence number before the syscall(read())
- * 
- * In uprobe http2 read() (after syscall read()), lookup TCP sequence number recorded previously on the map.
- * e.g.: In uprobe_go_http2serverConn_processHeaders(), get TCP sequence before syscall read(). 
- * 
- * Note:  Use for after uprobe read() only.
- */
-struct bpf_map_def SEC("maps") http2_tcp_seq_map = {
-	.type = BPF_MAP_TYPE_LRU_HASH,
-	.key_size = sizeof(struct http2_tcp_seq_key),
-	.value_size = sizeof(__u32),
-	.max_entries = 10240,
-};
-
 /*
  *  uprobe_go_tls_write_enter  (In tls_conn_map record A(tcp_seq) before syscall)
  *               |

--- a/agent/src/ebpf/kernel/uprobe_base_bpf.c
+++ b/agent/src/ebpf/kernel/uprobe_base_bpf.c
@@ -16,6 +16,28 @@
 
 #define HASH_ENTRIES_MAX 40960
 
+struct http2_tcp_seq_key {
+	int tgid;
+	int fd;
+	__u32 tcp_seq_end;
+};
+
+/*
+ * In uprobe_go_tls_read_exit()
+ * Save the TCP sequence number before the syscall(read())
+ * 
+ * In uprobe http2 read() (after syscall read()), lookup TCP sequence number recorded previously on the map.
+ * e.g.: In uprobe_go_http2serverConn_processHeaders(), get TCP sequence before syscall read(). 
+ * 
+ * Note:  Use for after uprobe read() only.
+ */
+struct bpf_map_def SEC("maps") http2_tcp_seq_map = {
+	.type = BPF_MAP_TYPE_LRU_HASH,
+	.key_size = sizeof(struct http2_tcp_seq_key),
+	.value_size = sizeof(__u32),
+	.max_entries = 10240,
+};
+
 /*
  * The binary executable file offset of the GO process
  * key: pid


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the problem that the tcp seq sequence number is 0
#### Steps to reproduce the bug

- View http2 packets obtained by uprobe

#### Changes to fix the bug

- Add a flag to confirm that all data was successfully fetched
- Get the tcp sequence number before and after read operation from kprobe

#### Affected branches

- main

#### Checklist
- [ ] Added unit test to verify the fix.
