### PR TITLE
[eBPF] Fix HTTP2 uprobe stream id

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -456,7 +456,11 @@ int uprobe_go_http2ClientConn_writeHeader(struct pt_regs *ctx)
 	void *ptr = get_the_first_parameter(ctx, info);
 	ptr += info->offsets[OFFSET_IDX_STREAM_HTTP2_CLIENT_CONN];
 	bpf_probe_read(&(data.stream), sizeof(data.stream), ptr);
-	data.stream -= 2;
+
+	// FIXME: Need a more precise version number
+	if (info->version >= GO_VERSION(1, 15, 0)) {
+		data.stream -= 2;
+	}
 
 	struct __http2_stack *stack = get_http2_stack();
 	if (!stack) {
@@ -500,10 +504,14 @@ int uprobe_go_http2ClientConn_writeHeaders(struct pt_regs *ctx)
 	}
 
 	struct http2_header_data data = {};
-	void *ptr = get_the_first_parameter(ctx, info);
-	ptr += info->offsets[OFFSET_IDX_STREAM_HTTP2_CLIENT_CONN];
-	bpf_probe_read(&(data.stream), sizeof(data.stream), ptr);
-	data.stream -= 2;
+
+	if (info->version >= GO_VERSION(1, 17, 0)) {
+		data.stream = (__u32)ctx->rbx;
+	} else {
+		bpf_probe_read(&(data.stream), sizeof(data.stream),
+			       (void *)(ctx->rsp + 16));
+	}
+
 	data.read = false;
 	data.fd = get_fd_from_http2ClientConn_ctx(ctx, info);
 	data.message_type = MSG_REQUEST_END;

--- a/agent/src/ebpf/samples/rust/src/main.rs
+++ b/agent/src/ebpf/samples/rust/src/main.rs
@@ -26,6 +26,7 @@ use std::time::{Duration, UNIX_EPOCH};
 
 extern "C" {
     fn print_dns_info(data: *mut c_char, len: c_uint);
+    fn print_uprobe_http2_info(data: *mut c_char, len: c_uint);
 }
 
 fn flow_info(sd: *mut SK_BPF_DATA) -> String {
@@ -212,6 +213,8 @@ extern "C" fn socket_trace_callback(sd: *mut SK_BPF_DATA) {
                      (*sd).timestamp);
             if sk_proto_safe(sd) == SOCK_DATA_DNS {
                 print_dns_info((*sd).cap_data, (*sd).cap_len);
+            } else if (*sd).source == 2 {
+                print_uprobe_http2_info((*sd).cap_data, (*sd).cap_len);
             } else {
                 for x in data.into_iter() {
                     if x < 32 || x > 126 {

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -1325,6 +1325,29 @@ static unsigned char *read_name(unsigned char *reader, unsigned char *buffer,
 	return name;
 }
 
+struct http2_buffer_header {
+	__u32 fd;
+	__u32 stream_id;
+	__u32 header_len;
+	__u32 value_len;
+};
+
+void print_uprobe_http2_info(const char *data, int len)
+{
+	struct http2_buffer_header header;
+	char key[256] = { 0 };
+	char value[256] = { 0 };
+	memcpy(&header, data, sizeof(header));
+	printf("fd=[%d]\n", header.fd);
+	printf("stream_id=[%d]\n", header.stream_id);
+	memcpy(&key, data + sizeof(header), header.header_len);
+	memcpy(&value, data + sizeof(header) + header.header_len,
+	       header.value_len);
+	printf("header=[%s:%s]\n", key, value);
+	fflush(stdout);
+	return;
+}
+
 void print_dns_info(const char *data, int len)
 {
 	//refer: https://www.binarytides.com/dns-query-code-in-c-with-winsock/


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the error of getting stream id in lower version of golang
#### Steps to reproduce the bug

- Use the uprobe HTTP2 function of the lower version of golang

#### Changes to fix the bug

- Treated according to version number

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
