### PR TITLE
[cli] do not json parse response body when api response is not 200

### DIFF
--- a/cli/ctl/common/utils.go
+++ b/cli/ctl/common/utils.go
@@ -72,6 +72,9 @@ func CURLPerform(method string, url string, body map[string]interface{}, strBody
 	if err != nil {
 		return errResponse, errors.New(fmt.Sprintf("read (%s) body failed, (%v)", url, err))
 	}
+	if resp.StatusCode != http.StatusOK {
+		return errResponse, errors.New(fmt.Sprintf("curl (%s) failed, (%v)", url, string(respBytes)))
+	}
 
 	response, err := simplejson.NewJson(respBytes)
 	if err != nil {
@@ -79,7 +82,7 @@ func CURLPerform(method string, url string, body map[string]interface{}, strBody
 	}
 
 	optStatus := response.Get("OPT_STATUS").MustString()
-	if resp.StatusCode != http.StatusOK || (optStatus != "" && optStatus != SUCCESS) {
+	if optStatus != "" && optStatus != SUCCESS {
 		description := response.Get("DESCRIPTION").MustString()
 		return response, errors.New(fmt.Sprintf("curl (%s) failed, (%v)", url, description))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:

- CLI

### do not json parse response body when api response is not 200
#### Steps to reproduce the bug
#### Changes to fix the bug
- check response opt status
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
