### PR TITLE
[eBPF] Fix Go 1.15 HTTP2 uprobe stream id

### DIFF
--- a/agent/src/ebpf/kernel/go_http2_bpf.c
+++ b/agent/src/ebpf/kernel/go_http2_bpf.c
@@ -457,8 +457,7 @@ int uprobe_go_http2ClientConn_writeHeader(struct pt_regs *ctx)
 	ptr += info->offsets[OFFSET_IDX_STREAM_HTTP2_CLIENT_CONN];
 	bpf_probe_read(&(data.stream), sizeof(data.stream), ptr);
 
-	// FIXME: Need a more precise version number
-	if (info->version >= GO_VERSION(1, 15, 0)) {
+	if (info->version >= GO_VERSION(1, 16, 0)) {
 		data.stream -= 2;
 	}
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes Go 1.15 HTTP2 uprobe stream id
#### Steps to reproduce the bug

- Use the http uprobe function of go1.15

#### Changes to fix the bug

- fix version number

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
