### PR TITLE
[AGENT] adjust platformSynchronzier stop condition

### DIFF
--- a/agent/src/platform/platform_synchronizer.rs
+++ b/agent/src/platform/platform_synchronizer.rs
@@ -191,6 +191,7 @@ impl PlatformSynchronizer {
         }
 
         self.stop_kubernetes_poller();
+        info!("PlatformSynchronizer stopped");
     }
 
     pub fn start(&self) {
@@ -225,6 +226,7 @@ impl PlatformSynchronizer {
         if is_tt_pod(self.config.load().trident_type) {
             self.kubernetes_poller.start();
         }
+        info!("PlatformSynchronizer started");
     }
 
     fn query_platform(


### PR DESCRIPTION
Fix:


### This PR is for:


- Agent

### Fixes when agent's tap_mode is Mirror, platformSynchronizer will not stop

#### Changes to fix the bug
- make platformSynchronzier stop when RuntimeConfig::TapMode != TapMode::Local and RuntimeConfig::enabled is true

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
