### PR TITLE
[eBPF] Clear feature flang when tracer stop

### DIFF
--- a/agent/src/ebpf/user/tracer.c
+++ b/agent/src/ebpf/user/tracer.c
@@ -1270,6 +1270,8 @@ int tracer_stop(void)
 	struct bpf_tracer *t = NULL;
 	int i, ret = 0;
 
+	memset(feature_flags, 0, sizeof(feature_flags));
+
 	for (i = 0; i < tracers_count; i++) {
 		t = tracers[i];
 		ret = t->stop_handle();


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the remaining feature flags are not cleaned up when restarting ebpfs

#### Steps to reproduce the bug

- Restart eBPF

#### Changes to fix the bug

- Clear feature flang when tracer stop

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
