### PR TITLE
[eBPF] Fix memory leaks(#1022)

### DIFF
--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -262,7 +262,6 @@ struct symbol_uprobe *resolve_and_gen_uprobe_symbol(const char *bin_file,
 
 	uprobe_sym->type = sym->type;
 	uprobe_sym->isret = sym->is_probe_ret;
-	uprobe_sym->name = strdup(sym->symbol);
 	uprobe_sym->pid = pid;
 	uprobe_sym->probe_func = strdup(sym->probe_func);
 	/*


### PR DESCRIPTION
In function resolve_and_gen_uprobe_symbol(), call strdup(sym->symbol) twice, memory leaks occur.



### This PR is for:

- Agent

Fixes #(1022)

