### PR TITLE
[Agent] fix analyzer mode bugs

### DIFF
--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -423,15 +423,13 @@ impl<'a> MetaPacket<'a> {
                 error::Error::ParsePacketFailed(format!("parse eth_type failed: {}", e))
             })?;
             if eth_type == EthernetType::Dot1Q {
-                vlan_tag_size = VLAN_HEADER_SIZE;
+                vlan_tag_size += VLAN_HEADER_SIZE;
                 size_checker -= VLAN_HEADER_SIZE as isize;
                 if size_checker < 0 {
                     return Err(error::Error::ParsePacketFailed("packet truncated".into()));
                 }
-                let vlan_tag = read_u16_be(
-                    &packet
-                        [FIELD_OFFSET_ETH_TYPE + ETH_TYPE_LEN + ETH_TYPE_LEN + VLAN_HEADER_SIZE..],
-                );
+                let vlan_tag =
+                    read_u16_be(&packet[FIELD_OFFSET_ETH_TYPE + VLAN_HEADER_SIZE + ETH_TYPE_LEN..]);
                 self.vlan = vlan_tag & VLAN_ID_MASK;
                 eth_type = EthernetType::try_from(read_u16_be(
                     &packet[FIELD_OFFSET_ETH_TYPE + vlan_tag_size..],

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -1041,6 +1041,14 @@ impl ConfigHandler {
             );
         }
 
+        if yaml_config.mirror_traffic_pcp != new_config.yaml_config.mirror_traffic_pcp {
+            yaml_config.mirror_traffic_pcp = new_config.yaml_config.mirror_traffic_pcp;
+            info!(
+                "mirror_traffic_pcp set to {:?}",
+                yaml_config.mirror_traffic_pcp
+            );
+        }
+
         if candidate_config.dispatcher != new_config.dispatcher {
             if candidate_config.dispatcher.if_mac_source != new_config.dispatcher.if_mac_source {
                 if candidate_config.tap_mode != TapMode::Local {

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -398,6 +398,9 @@ impl Trident {
                         vm_mac_addrs,
                     )?;
                     comp.start();
+                    if config_handler.candidate_config.dispatcher.tap_mode == TapMode::Analyzer {
+                        parse_tap_type(&mut comp, tap_types);
+                    }
                     for callback in callbacks {
                         callback(&config_handler, &mut comp);
                     }
@@ -486,24 +489,28 @@ fn dispatcher_listener_callback(
                 );
                 listener.on_vm_change(&vm_mac_addrs);
             }
-            let mut updated = false;
-            if components.cur_tap_types.len() != tap_types.len() {
-                updated = true;
-            } else {
-                for i in 0..tap_types.len() {
-                    if components.cur_tap_types[i] != tap_types[i] {
-                        updated = true;
-                        break;
-                    }
-                }
-            }
-            if updated {
-                components.tap_typer.on_tap_types_change(tap_types.clone());
-                components.cur_tap_types.clear();
-                components.cur_tap_types.clone_from(&tap_types);
-            }
+            parse_tap_type(components, tap_types);
         }
         _ => {}
+    }
+}
+
+fn parse_tap_type(components: &mut Components, tap_types: Vec<trident::TapType>) {
+    let mut updated = false;
+    if components.cur_tap_types.len() != tap_types.len() {
+        updated = true;
+    } else {
+        for i in 0..tap_types.len() {
+            if components.cur_tap_types[i] != tap_types[i] {
+                updated = true;
+                break;
+            }
+        }
+    }
+    if updated {
+        components.tap_typer.on_tap_types_change(tap_types.clone());
+        components.cur_tap_types.clear();
+        components.cur_tap_types.clone_from(&tap_types);
     }
 }
 


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes analyzer mode bugs and meta_packet's update
#### Steps to reproduce the bug
- No l4 log data can be searched by tap
- The l4 log data searched by vtap is incorrect
#### Changes to fix the bug
- Fixes if it is a two-layer vlan, the vlan ID is obtained incorrectly during meta_packet update
- Update the distributed tap_types when initializing the dispatcher
- Implementation of aligned trident
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.