### PR TITLE
[eBPF] Remove the GPL definition from socket_trace.c(#1149)

### DIFF
--- a/agent/src/ebpf/kernel/socket_trace.c
+++ b/agent/src/ebpf/kernel/socket_trace.c
@@ -1463,5 +1463,3 @@ TPPROG(sys_exit_socket) (struct syscall_comm_exit_ctx *ctx) {
 #include "go_tls_bpf.c"
 #include "go_http2_bpf.c"
 #include "openssl_bpf.c"
-
-char _license[] SEC("license") = "GPL";

--- a/agent/src/ebpf/user/load.c
+++ b/agent/src/ebpf/user/load.c
@@ -176,7 +176,10 @@ static struct ebpf_object *create_new_obj(const void *buf, size_t buf_sz,
 static void set_obj__license(struct ebpf_object *obj)
 {
 	struct sec_desc *desc = obj->elf_info.license_sec;
-	memcpy(obj->license, desc->d_buf, desc->size);
+	if (desc->d_buf != NULL && desc->size > 0) {
+		memcpy(obj->license, desc->d_buf, desc->size);
+		obj->license[sizeof(obj->license) - 1] = '\0';
+	}
 	ebpf_info("license: %s\n", obj->license);
 }
 


### PR DESCRIPTION
```
char _license[] SEC("license") = "GPL";
```
Using default definitions during loading is not required in the file socket_trace.c.

### This PR is for:

- Agent



#### Affected branches
- main
