### PR TITLE
[eBPF] Fix tcp response sequence number is not obtained correctly(#1439)

### DIFF
--- a/agent/src/ebpf/kernel/include/socket_trace.h
+++ b/agent/src/ebpf/kernel/include/socket_trace.h
@@ -131,6 +131,7 @@ struct conn_info_t {
 	__s32 correlation_id; // 目前用于kafka判断
 	enum traffic_direction prev_direction;
 	struct socket_info_t *socket_info_ptr; /* lookup __socket_info_map */
+	unsigned char skc_state; // State of the current socket
 };
 
 enum process_data_extra_source {


### PR DESCRIPTION
If the current state is TCPF_CLOSE_WAIT, the FIN frame already has been received. Since tcp_sock->copied_seq has done such an operation +1, need to fix the value of tcp_seq.



### This PR is for:


- Agent


#### Affected branches
- main


Fixes #(1439)

