### PR TITLE
[eBPF] Solve the problem of excessive physical memory usage

### DIFF
--- a/agent/src/ebpf/README.md
+++ b/agent/src/ebpf/README.md
@@ -43,7 +43,7 @@ Trace to the Golang program is implemented by the following method:
 - Create probes and attach based on the parsed datas.
 - Capture process execute/exit events by tracking two tracepoints(`tracepoint/sched/sched_process_fork` and `tracepoint/sched/sched_process_exit`). Update probes based on captured events.
 
-Note: In order to avoid attaching/detaching the golang program repeatedly, it is necessary to confirm that the golang application has been running stably before DeepFlow-agent starts the attach operation. After DeepFlow-agent detects that the golang application is loaded, it delays the attach operation for 120 seconds. Openssl only supports kernel 4.17 and above.
+Note: In order to avoid attaching/detaching the golang program repeatedly, it is necessary to confirm that the golang application has been running stably before DeepFlow-agent starts the attach operation. After DeepFlow-agent detects that the golang application is loaded, it delays the attach operation for 60 seconds. Openssl only supports kernel 4.17 and above.
 
 # Implement logic
 

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -39,7 +39,7 @@
  *
  * 在socket map回收时，对每条socket信息超过10秒没有收发动作就回收掉
  */
-#define SOCKET_RECLAIM_TIMEOUT_DEF  10
+#define SOCKET_RECLAIM_TIMEOUT_DEF	10
 
 /*
  * When the trace map is recycled, each trace information is recycled without a matching
@@ -47,9 +47,14 @@
  *
  * 在trace map回收时，对每条trace信息超过10秒没有发生匹配动作就回收掉
  */
-#define TRACE_RECLAIM_TIMEOUT_DEF   10
+#define TRACE_RECLAIM_TIMEOUT_DEF	10
 
 // The maximum default amount of data passed to the agent by eBPF programe.
-#define SOCKET_DATA_LIMIT_MAX_DEF   4096
+#define SOCKET_DATA_LIMIT_MAX_DEF	4096
+
+#define MAP_PROC_INFO_MAP_NAME		"proc_info_map"
+
+// execute/exit events delayed processing time, unit: second
+#define PROC_EVENT_DELAY_HANDLE_DEF     60
 
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/elf.c
+++ b/agent/src/ebpf/user/elf.c
@@ -39,7 +39,7 @@ int openelf(const char *path, Elf ** elf, int *fd)
 		goto failed;
 	}
 
-	if (!(*elf = elf_begin(*fd, ELF_C_READ, 0))) {
+	if (!(*elf = elf_begin(*fd, ELF_C_READ_MMAP, 0))) {
 		goto failed;
 	}
 

--- a/agent/src/ebpf/user/symbol.c
+++ b/agent/src/ebpf/user/symbol.c
@@ -387,9 +387,11 @@ invalid:
 
 char *get_elf_path_by_pid(int pid)
 {
-	int ret;
+#define PROC_PREFIX_LEN 32
+
+	int ret, len;
 	char bin_path[PATH_MAX], *path;
-	char proc_pid_exe[32];
+	char proc_pid_exe[PROC_PREFIX_LEN];
 	memset(bin_path, 0, sizeof(bin_path));
 	memset(proc_pid_exe, 0, sizeof(proc_pid_exe));
 
@@ -403,23 +405,23 @@ char *get_elf_path_by_pid(int pid)
 		return NULL;
 	}
 
-	path = calloc(1, PATH_MAX);
+	len = strlen(bin_path) + PROC_PREFIX_LEN;
+	path = calloc(1, len);
 	if (path == NULL)
 		return NULL;
-	if (snprintf(path, PATH_MAX, "/proc/%d/root%s", pid, bin_path)
-	    >= PATH_MAX) {
+	if (snprintf(path, len, "/proc/%d/root%s", pid, bin_path)
+	    >= len) {
 		ebpf_warning("snprintf /proc/%d/root%s failed", pid, bin_path);
 		free(path);
 		return NULL;
 	}
 
 	if (access(path, F_OK) != 0) {
-		memset(path, 0, PATH_MAX);
-		safe_buf_copy(path, PATH_MAX, bin_path, sizeof(bin_path));
+		memset(path, 0, len);
+		safe_buf_copy(path, len, bin_path, sizeof(bin_path));
 	}
 
 	return path;
-
 }
 
 #if defined(__x86_64__)


### PR DESCRIPTION
- After the uprobe function was enabled, it was found that the resident physical memory occupied too much, because libelf used malloc() and did not return the memory to the system after free(). We use MMAP instead of malloc() is a good solution.

- In addition, the PROC_EVENT_DELAY_HANDLE_DEF (120s) setting is too large, resulting in a backlog of unprocessed events. Now set PROC_EVENT_DELAY_HANDLE_DEF to 60s.

PROC_EVENT_DELAY_HANDLE_DEF (execute/exit events delayed processing time, unit: second)

- Test:

cat /proc/PID/status  (rust_sample)

Before adjustment:

	VmRSS:     112600 kB

After adjustment:

	VmRSS:     37064 kB


### This PR is for:


- Agent



#### Affected branches
- main



Fixes #(1502)

