### PR TITLE
[Agent] fix http1 header parse limit

### DIFF
--- a/agent/src/collector/quadruple_generator.rs
+++ b/agent/src/collector/quadruple_generator.rs
@@ -884,7 +884,8 @@ impl QuadrupleGenerator {
         }
 
         if minute_inject {
-            for i in 0..2 { // policy_ids are only used for the calculation of vtap_acl metrics
+            for i in 0..2 {
+                // policy_ids are only used for the calculation of vtap_acl metrics
                 for action in tagged_flow.tag.policy_data[i].npb_actions.iter() {
                     for gid in action.acl_gids().iter() {
                         self.policy_ids[i].add(*gid);

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -566,7 +566,7 @@ impl TraceType {
             TraceType::Sw6 => context == TRACE_TYPE_SW6,
             TraceType::Sw8 => context == TRACE_TYPE_SW8,
             TraceType::TraceParent => context == TRACE_TYPE_TRACE_PARENT,
-            TraceType::Customize(tag) => context == tag.as_str(),
+            TraceType::Customize(tag) => context.to_lowercase() == tag.to_lowercase(),
             _ => false,
         }
     }


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes http1 header parse limit 20 lead to trace_id not extract
#### Steps to reproduce the bug
- send http1 with trace_id after 20 line
#### Changes to fix the bug
- parse http1 header to payload end

#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
