### PR TITLE
[Agent] fix mirror mode pipeline's key and add log

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -1101,6 +1101,10 @@ impl ConfigHandler {
             info!("src_interfaces set to {:?}", yaml_config.src_interfaces);
         }
 
+        if candidate_config.tap_mode != TapMode::Local && yaml_config.src_interfaces.is_empty() {
+            warn!("src_interfaces should be set in Analyzer mode or Mirror mode");
+        }
+
         if yaml_config.analyzer_dedup_disabled != new_config.yaml_config.analyzer_dedup_disabled {
             yaml_config.analyzer_dedup_disabled = new_config.yaml_config.analyzer_dedup_disabled;
             info!(
@@ -1145,10 +1149,8 @@ impl ConfigHandler {
                 }
             }
 
-            // TODO should support tap-interface-regex on linux
             #[cfg(target_os = "windows")]
-            if (candidate_config.tap_mode == TapMode::Local
-                || candidate_config.tap_mode == TapMode::Mirror)
+            if candidate_config.tap_mode == TapMode::Local
                 && candidate_config.dispatcher.tap_interface_regex
                     != new_config.dispatcher.tap_interface_regex
             {

--- a/agent/src/dispatcher/base_dispatcher.rs
+++ b/agent/src/dispatcher/base_dispatcher.rs
@@ -214,9 +214,7 @@ impl BaseDispatcher {
     }
 
     pub(super) fn switch_recv_engine(&mut self, pcap_interfaces: Vec<Link>) -> Result<()> {
-        self.engine = if (self.options.tap_mode == TapMode::Local
-            || self.options.tap_mode == TapMode::Mirror)
-        {
+        self.engine = if self.options.tap_mode == TapMode::Local {
             if pcap_interfaces.is_empty() {
                 return Err(Error::WinPcap(
                     "windows pcap capture must give interface to capture packet".into(),

--- a/agent/src/dispatcher/mirror_mode_dispatcher.rs
+++ b/agent/src/dispatcher/mirror_mode_dispatcher.rs
@@ -448,7 +448,7 @@ impl MirrorModeDispatcher {
             if !src_local && !dst_local {
                 let _ = Self::handler(
                     self.base.id,
-                    da_key,
+                    self.mac, // In order for two-way traffic to be handled by the same pipeline, self.mac is used as the key here
                     src_local,
                     dst_local,
                     overlay_packet,
@@ -588,9 +588,5 @@ impl MirrorModeDispatcher {
         };
 
         return decap_length;
-    }
-
-    pub(super) fn switch_recv_engine(&mut self, pcap_interfaces: Vec<Link>) -> Result<()> {
-        self.base.switch_recv_engine(pcap_interfaces)
     }
 }

--- a/agent/src/dispatcher/mod.rs
+++ b/agent/src/dispatcher/mod.rs
@@ -122,7 +122,6 @@ impl DispatcherFlavor {
     fn switch_recv_engine(&mut self, pcap_interfaces: Vec<Link>) -> Result<()> {
         match self {
             DispatcherFlavor::Local(d) => d.switch_recv_engine(pcap_interfaces),
-            DispatcherFlavor::Mirror(d) => d.switch_recv_engine(pcap_interfaces),
             _ => todo!(),
         }
     }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes mirror mode pipeline's key and add log
#### Steps to reproduce the bug
- the src_interfaces should be set in Analyzer mode or Mirror mode
#### Changes to fix the bug
- when !src_local && !dst_local, change mirror pipeline's key from da_key to mac
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
