### PR TITLE
[Agent] Fix panic in ipv6 tcp parsing #19947

### DIFF
--- a/agent/src/common/meta_packet.rs
+++ b/agent/src/common/meta_packet.rs
@@ -485,7 +485,7 @@ impl<'a> MetaPacket<'a> {
             }
             EthernetType::Ipv6 => {
                 is_ipv6 = true;
-                size_checker -= HeaderType::Ipv6.min_header_size() as isize;
+                size_checker -= (HeaderType::Ipv6.min_header_size() + IPV6_HEADER_ADJUST) as isize;
                 if size_checker < 0 {
                     return Ok(());
                 }
@@ -531,6 +531,7 @@ impl<'a> MetaPacket<'a> {
 
                 size_checker -= options_length as isize;
                 if size_checker < 0 {
+                    self.npb_ignore_l4 = true;
                     return Ok(());
                 }
                 self.l3_payload_len = size_checker as usize;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fix panic in ipv6 tcp parsing
#### Steps to reproduce the bug
#### Changes to fix the bug
-  The ipv6 header length check is incorrect
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
