### PR TITLE
[Agent] Fixes cgroup does not restrict the CPU

### DIFF
--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -23,12 +23,11 @@ use std::path::PathBuf;
 #[cfg(target_os = "linux")]
 use std::process;
 use std::sync::Arc;
+use std::thread;
 use std::time::Duration;
 
 use arc_swap::{access::Map, ArcSwap};
 use bytesize::ByteSize;
-#[cfg(target_os = "linux")]
-use cgroups_rs::{CpuResources, MemoryResources, Resources};
 use flexi_logger::writers::FileLogWriter;
 use flexi_logger::{Age, Cleanup, Criterion, FileSpec, LoggerHandle, Naming};
 use log::{info, warn, Level};
@@ -42,13 +41,6 @@ use super::{
 };
 use crate::common::l7_protocol_log::L7ProtocolBitmap;
 use crate::flow_generator::protocol_logs::SOFA_NEW_RPC_TRACE_CTX_KEY;
-#[cfg(target_os = "linux")]
-use crate::{
-    common::DEFAULT_CPU_CFS_PERIOD_US,
-    dispatcher::recv_engine::af_packet::OptTpacketVersion,
-    ebpf::CAP_LEN_MAX,
-    utils::{cgroups::Cgroups, environment::is_tt_pod, environment::is_tt_workload},
-};
 use crate::{
     common::{decapsulate::TunnelTypeBitmap, enums::TapType},
     dispatcher::recv_engine,
@@ -57,9 +49,15 @@ use crate::{
     handler::PacketHandlerBuilder,
     trident::{Components, RunningMode},
     utils::{
-        environment::{free_memory_check, get_ctrl_ip_and_mac},
+        environment::{free_memory_check, get_ctrl_ip_and_mac, running_in_container},
         logger::RemoteLogConfig,
     },
+};
+#[cfg(target_os = "linux")]
+use crate::{
+    dispatcher::recv_engine::af_packet::OptTpacketVersion,
+    ebpf::CAP_LEN_MAX,
+    utils::{cgroups::Cgroups, environment::is_tt_pod, environment::is_tt_workload},
 };
 
 use public::bitmap::Bitmap;
@@ -1125,9 +1123,7 @@ impl ConfigHandler {
             candidate_config.tap_mode = new_config.tap_mode;
         }
 
-        if candidate_config.tap_mode != TapMode::Analyzer
-            && static_config.kubernetes_cluster_id.is_empty()
-        {
+        if candidate_config.tap_mode != TapMode::Analyzer && !running_in_container() {
             // Check and send out exceptions in time
             if let Err(e) = free_memory_check(new_config.environment.max_memory, exception_handler)
             {
@@ -1240,7 +1236,7 @@ impl ConfigHandler {
                                 }
                             }
                             _ => {
-                                if handler.static_config.kubernetes_cluster_id.is_empty() {
+                                if !running_in_container() {
                                     match free_memory_check(
                                         handler.candidate_config.environment.max_memory,
                                         &components.exception_handler,
@@ -1427,9 +1423,7 @@ impl ConfigHandler {
             }
         }
 
-        if candidate_config.tap_mode != TapMode::Analyzer
-            && static_config.kubernetes_cluster_id.is_empty()
-        {
+        if candidate_config.tap_mode != TapMode::Analyzer && !running_in_container() {
             #[cfg(target_os = "linux")]
             {
                 let max_memory_change =
@@ -1437,77 +1431,29 @@ impl ConfigHandler {
                 let max_cpu_change =
                     candidate_config.environment.max_cpus != new_config.environment.max_cpus;
                 if max_memory_change || max_cpu_change {
-                    if static_config.kubernetes_cluster_id.is_empty() {
-                        // 非容器类型采集器才做资源限制
-                        fn cgroup_callback(handler: &ConfigHandler, components: &mut Components) {
-                            if components.cgroups_controller.cgroup.is_none() {
-                                match Cgroups::new() {
-                                    Ok(cc) => {
-                                        if let Some(_) = &cc.cgroup {
-                                            match cc.init(process::id() as u64) {
-                                                Ok(cgroup) => {
-                                                    components.cgroups_controller =
-                                                        Arc::new(cgroup);
-                                                }
-                                                Err(e) => {
-                                                    warn!("{}", e);
-                                                }
-                                            }
-                                        }
-                                    }
-                                    Err(e) => {
-                                        warn!("{:?}", e);
-                                    }
-                                };
-                            }
-
-                            let mut resources = Resources {
-                                memory: Default::default(),
-                                pid: Default::default(),
-                                cpu: Default::default(),
-                                devices: Default::default(),
-                                network: Default::default(),
-                                hugepages: Default::default(),
-                                blkio: Default::default(),
-                            };
-                            if handler.candidate_config.environment.max_memory != 0 {
-                                let memory_resources = MemoryResources {
-                                    kernel_memory_limit: None,
-                                    memory_hard_limit: Some(
-                                        handler.candidate_config.environment.max_memory as i64,
-                                    ),
-                                    memory_soft_limit: None,
-                                    kernel_tcp_memory_limit: None,
-                                    memory_swap_limit: None,
-                                    swappiness: None,
-                                    attrs: Default::default(),
-                                };
-                                resources.memory = memory_resources.clone();
-                            }
-                            if handler.candidate_config.environment.max_cpus != 0 {
-                                let cpu_quota = handler.candidate_config.environment.max_cpus
-                                    * DEFAULT_CPU_CFS_PERIOD_US;
-                                let cpu_resources = CpuResources {
-                                    cpus: None,
-                                    mems: None,
-                                    shares: None,
-                                    quota: Some(cpu_quota as i64),
-                                    period: Some(DEFAULT_CPU_CFS_PERIOD_US as u64),
-                                    realtime_runtime: None,
-                                    realtime_period: None,
-                                    attrs: Default::default(),
-                                };
-                                resources.cpu = cpu_resources.clone();
-                            }
-                            match components.cgroups_controller.apply(&resources) {
-                                Ok(_) => {}
+                    fn cgroup_callback(handler: &ConfigHandler, components: &mut Components) {
+                        if components.cgroups_controller.is_none() {
+                            components.cgroups_controller = match Cgroups::new(process::id() as u64)
+                            {
+                                Ok(cg_controller) => Some(cg_controller),
                                 Err(e) => {
-                                    warn!("set cgroups failed: {}", e);
+                                    warn!("initialize cgroup controller failed, {:?}, agent restart...", e);
+                                    thread::sleep(Duration::from_secs(1));
+                                    process::exit(1);
                                 }
-                            }
+                            };
+                        };
+
+                        if let Err(e) = components.cgroups_controller.as_mut().unwrap().apply(
+                            handler.candidate_config.environment.max_cpus,
+                            handler.candidate_config.environment.max_memory,
+                        ) {
+                            warn!("apply cgroup resource failed, {:?}, agent restart...", e);
+                            thread::sleep(Duration::from_secs(1));
+                            process::exit(1);
                         }
-                        callbacks.push(cgroup_callback);
                     }
+                    callbacks.push(cgroup_callback);
                 }
             }
 
@@ -1523,8 +1469,7 @@ impl ConfigHandler {
                 info!("cpu limit set to {}", new_config.environment.max_cpus);
                 candidate_config.environment.max_cpus = new_config.environment.max_cpus;
             }
-        } else if (candidate_config.tap_mode == TapMode::Analyzer
-            || !static_config.kubernetes_cluster_id.is_empty())
+        } else if (candidate_config.tap_mode == TapMode::Analyzer || running_in_container())
             && candidate_config.environment.max_memory != 0
         {
             info!("memory set ulimit when tap_mode=analyzer or running in a K8s pod");
@@ -1930,8 +1875,7 @@ impl ConfigHandler {
                 for dispatcher in components.dispatchers.iter() {
                     dispatcher.stop();
                 }
-                if handler.candidate_config.tap_mode != TapMode::Analyzer
-                    && handler.static_config.kubernetes_cluster_id.is_empty()
+                if handler.candidate_config.tap_mode != TapMode::Analyzer && !running_in_container()
                 {
                     match free_memory_check(
                         handler.candidate_config.environment.max_memory,

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -756,7 +756,7 @@ pub struct Components {
     pub running: AtomicBool,
     pub stats_collector: Arc<stats::Collector>,
     #[cfg(target_os = "linux")]
-    pub cgroups_controller: Arc<Cgroups>,
+    pub cgroups_controller: Option<Cgroups>,
     pub external_metrics_server: MetricServer,
     pub otel_uniform_sender: UniformSenderThread<OpenTelemetry>,
     pub prometheus_uniform_sender: UniformSenderThread<PrometheusMetric>,
@@ -1437,7 +1437,7 @@ impl Components {
         #[allow(unused)]
         let mut ebpf_collector = None;
         #[cfg(target_os = "linux")]
-        if config_handler.candidate_config.tap_mode != TapMode::Analyzer {
+        if candidate_config.tap_mode != TapMode::Analyzer {
             let ebpf_dispatcher_id = dispatchers.len();
             let (flow_sender, flow_receiver, counter) = queue::bounded_with_debug(
                 yaml_config.flow_queue_size,
@@ -1512,7 +1512,31 @@ impl Components {
             }
         }
         #[cfg(target_os = "linux")]
-        let cgroups_controller: Arc<Cgroups> = Arc::new(Cgroups { cgroup: None });
+        let mut cgroups_controller = None;
+        #[cfg(target_os = "linux")]
+        if candidate_config.tap_mode != TapMode::Analyzer && !running_in_container() {
+            match Cgroups::new(process::id() as u64) {
+                Ok(cg_controller) => {
+                    if let Err(e) = cg_controller.apply(
+                        candidate_config.environment.max_cpus,
+                        candidate_config.environment.max_memory,
+                    ) {
+                        warn!("apply cgroup resource failed, {:?}, agent restart...", e);
+                        thread::sleep(Duration::from_secs(1));
+                        process::exit(1);
+                    }
+                    cgroups_controller = Some(cg_controller);
+                }
+                Err(e) => {
+                    warn!(
+                        "initialize cgroup controller failed, {:?}, agent restart...",
+                        e
+                    );
+                    thread::sleep(Duration::from_secs(1));
+                    process::exit(1);
+                }
+            };
+        }
 
         let sender_id = get_sender_id() as usize;
         let otel_queue_name = "otel-to-sender";
@@ -1880,12 +1904,14 @@ impl Components {
             ebpf_collector.stop();
         }
         #[cfg(target_os = "linux")]
-        match self.cgroups_controller.stop() {
-            Ok(_) => {
-                info!("stopped cgroups_controller");
-            }
-            Err(e) => {
-                warn!("stop cgroups_controller failed: {}", e);
+        if self.cgroups_controller.is_some() {
+            match self.cgroups_controller.as_ref().unwrap().stop() {
+                Ok(_) => {
+                    info!("stopped cgroups_controller");
+                }
+                Err(e) => {
+                    warn!("stop cgroups_controller failed: {}", e);
+                }
             }
         }
 

--- a/agent/src/utils/cgroups.rs
+++ b/agent/src/utils/cgroups.rs
@@ -18,6 +18,7 @@ use std::fs;
 
 use cgroups_rs::cgroup_builder::*;
 use cgroups_rs::*;
+use public::consts::{DEFAULT_CPU_CFS_PERIOD_US, PROCESS_NAME};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -36,13 +37,12 @@ pub enum Error {
 
 #[derive(Clone)]
 pub struct Cgroups {
-    pub cgroup: Option<Cgroup>,
+    pub cgroup: Cgroup,
 }
 
 impl Cgroups {
     /// 创建cgroup hierarchy
-    pub fn new() -> Result<Self, Error> {
-        let mut cgroups = Cgroups { cgroup: None };
+    pub fn new(pid: u64) -> Result<Self, Error> {
         let contents = match fs::read_to_string("/proc/filesystems") {
             Ok(file_contents) => file_contents,
             Err(e) => {
@@ -63,52 +63,44 @@ impl Cgroups {
             )));
         }
         let hier = hierarchies::auto();
-        let cg: Cgroup = CgroupBuilder::new("deepflow-agent").build(hier);
-        cgroups.cgroup = Some(cg);
-        Ok(cgroups)
-    }
-
-    /// 初始化cgroup，将pid写入cgroup的tasks中
-    pub fn init(&self, pid: u64) -> Result<Self, Error> {
-        if let Some(ref cg) = self.cgroup {
-            let cpus: &cpu::CpuController = cg.controller_of().unwrap();
-            match cpus.add_task(&CgroupPid::from(pid)) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::CpuControllerSetFailed(e.to_string()));
-                }
-            }
-            let mem: &memory::MemController = cg.controller_of().unwrap();
-            match mem.add_task(&CgroupPid::from(pid)) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::MemControllerSetFailed(e.to_string()));
-                }
-            }
-        };
-        Ok(self.clone())
+        let cg: Cgroup = CgroupBuilder::new(PROCESS_NAME).build(hier);
+        let cpus: &cpu::CpuController = cg.controller_of().unwrap();
+        if let Err(e) = cpus.add_task_by_tgid(&CgroupPid::from(pid)) {
+            return Err(Error::CpuControllerSetFailed(e.to_string()));
+        }
+        let mem: &memory::MemController = cg.controller_of().unwrap();
+        if let Err(e) = mem.add_task_by_tgid(&CgroupPid::from(pid)) {
+            return Err(Error::MemControllerSetFailed(e.to_string()));
+        }
+        Ok(Cgroups { cgroup: cg })
     }
 
     /// 更改资源限制
-    pub fn apply(&self, resources: &Resources) -> Result<(), Error> {
-        if let Some(c) = &self.cgroup {
-            match c.apply(resources) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::ApplyResourcesFailed(e.to_string()));
-                }
-            }
+    pub fn apply(&self, max_cpus: u32, max_memory: u64) -> Result<(), Error> {
+        let mut resources = Resources::default();
+        let cpu_quota = max_cpus * DEFAULT_CPU_CFS_PERIOD_US;
+        let cpu_resources = CpuResources {
+            quota: Some(cpu_quota as i64),
+            period: Some(DEFAULT_CPU_CFS_PERIOD_US as u64),
+            ..Default::default()
+        };
+        resources.cpu = cpu_resources;
+
+        let memory_resources = MemoryResources {
+            memory_hard_limit: Some(max_memory as i64),
+            ..Default::default()
+        };
+        resources.memory = memory_resources;
+        if let Err(e) = self.cgroup.apply(&resources) {
+            return Err(Error::ApplyResourcesFailed(e.to_string()));
         }
         Ok(())
     }
 
     /// 结束cgroup资源限制
     pub fn stop(&self) -> Result<(), Error> {
-        if let Some(c) = &self.cgroup {
-            match c.delete() {
-                Ok(_) => {}
-                Err(e) => return Err(Error::DeleteCgroupFailed(e.to_string())),
-            }
+        if let Err(e) = self.cgroup.delete() {
+            return Err(Error::DeleteCgroupFailed(e.to_string()));
         }
         Ok(())
     }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes cgroup does not restrict the CPU
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Judge whether the agent is an analyzer mode agent or runs in the container. If not, cgroup will be set when the agent starts running (fix the problem that cgroup is not set at the initial default value)
- Call the `add_task_by_tgid` method to add all the sub threads of the agent process to the path `/sys/fs/cgroup/cpu/deepflow-agent/tasks` to properly restrict the use of the agent's CPU
#### Affected branches
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.