### PR TITLE
[Agent] Fixes cgroup does not restrict the CPU

### DIFF
--- a/agent/src/utils/cgroups.rs
+++ b/agent/src/utils/cgroups.rs
@@ -18,6 +18,7 @@ use std::fs;
 
 use cgroups_rs::cgroup_builder::*;
 use cgroups_rs::*;
+use public::consts::{DEFAULT_CPU_CFS_PERIOD_US, PROCESS_NAME};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -36,13 +37,12 @@ pub enum Error {
 
 #[derive(Clone)]
 pub struct Cgroups {
-    pub cgroup: Option<Cgroup>,
+    pub cgroup: Cgroup,
 }
 
 impl Cgroups {
     /// 创建cgroup hierarchy
-    pub fn new() -> Result<Self, Error> {
-        let mut cgroups = Cgroups { cgroup: None };
+    pub fn new(pid: u64) -> Result<Self, Error> {
         let contents = match fs::read_to_string("/proc/filesystems") {
             Ok(file_contents) => file_contents,
             Err(e) => {
@@ -63,52 +63,44 @@ impl Cgroups {
             )));
         }
         let hier = hierarchies::auto();
-        let cg: Cgroup = CgroupBuilder::new("deepflow-agent").build(hier);
-        cgroups.cgroup = Some(cg);
-        Ok(cgroups)
-    }
-
-    /// 初始化cgroup，将pid写入cgroup的tasks中
-    pub fn init(&self, pid: u64) -> Result<Self, Error> {
-        if let Some(ref cg) = self.cgroup {
-            let cpus: &cpu::CpuController = cg.controller_of().unwrap();
-            match cpus.add_task(&CgroupPid::from(pid)) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::CpuControllerSetFailed(e.to_string()));
-                }
-            }
-            let mem: &memory::MemController = cg.controller_of().unwrap();
-            match mem.add_task(&CgroupPid::from(pid)) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::MemControllerSetFailed(e.to_string()));
-                }
-            }
-        };
-        Ok(self.clone())
+        let cg: Cgroup = CgroupBuilder::new(PROCESS_NAME).build(hier);
+        let cpus: &cpu::CpuController = cg.controller_of().unwrap();
+        if let Err(e) = cpus.add_task_by_tgid(&CgroupPid::from(pid)) {
+            return Err(Error::CpuControllerSetFailed(e.to_string()));
+        }
+        let mem: &memory::MemController = cg.controller_of().unwrap();
+        if let Err(e) = mem.add_task_by_tgid(&CgroupPid::from(pid)) {
+            return Err(Error::MemControllerSetFailed(e.to_string()));
+        }
+        Ok(Cgroups { cgroup: cg })
     }
 
     /// 更改资源限制
-    pub fn apply(&self, resources: &Resources) -> Result<(), Error> {
-        if let Some(c) = &self.cgroup {
-            match c.apply(resources) {
-                Ok(_) => {}
-                Err(e) => {
-                    return Err(Error::ApplyResourcesFailed(e.to_string()));
-                }
-            }
+    pub fn apply(&self, max_cpus: u32, max_memory: u64) -> Result<(), Error> {
+        let mut resources = Resources::default();
+        let cpu_quota = max_cpus * DEFAULT_CPU_CFS_PERIOD_US;
+        let cpu_resources = CpuResources {
+            quota: Some(cpu_quota as i64),
+            period: Some(DEFAULT_CPU_CFS_PERIOD_US as u64),
+            ..Default::default()
+        };
+        resources.cpu = cpu_resources;
+
+        let memory_resources = MemoryResources {
+            memory_hard_limit: Some(max_memory as i64),
+            ..Default::default()
+        };
+        resources.memory = memory_resources;
+        if let Err(e) = self.cgroup.apply(&resources) {
+            return Err(Error::ApplyResourcesFailed(e.to_string()));
         }
         Ok(())
     }
 
     /// 结束cgroup资源限制
     pub fn stop(&self) -> Result<(), Error> {
-        if let Some(c) = &self.cgroup {
-            match c.delete() {
-                Ok(_) => {}
-                Err(e) => return Err(Error::DeleteCgroupFailed(e.to_string())),
-            }
+        if let Err(e) = self.cgroup.delete() {
+            return Err(Error::DeleteCgroupFailed(e.to_string()));
         }
         Ok(())
     }


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes cgroup does not restrict the CPU
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Judge whether the agent is an analyzer mode agent or runs in the container. If not, cgroup will be set when the agent starts running (fix the problem that cgroup is not set at the initial default value)
- Call the add_task_by_tgid method to add all the sub threads of the agent process to the path /sys/fs/cgroup/cpu/deepflow-agent/tasks to properly restrict the use of the agent's CPU
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
