### PR TITLE
[Agent] Fix the ebpf http log lacks response data #20002

### DIFF
--- a/agent/src/flow_generator/app_table.rs
+++ b/agent/src/flow_generator/app_table.rs
@@ -171,7 +171,7 @@ impl AppTable {
         packet: &MetaPacket,
         local_epc: i32,
         remote_epc: i32,
-    ) -> Option<(L7ProtocolEnum, u16)> {
+    ) -> Option<L7ProtocolEnum> {
         if packet.lookup_key.is_loopback_packet() {
             return None;
         }
@@ -188,7 +188,7 @@ impl AppTable {
         };
         if dst_protocol.is_some() && dst_protocol.unwrap().get_l7_protocol() != L7Protocol::Unknown
         {
-            return Some((dst_protocol.unwrap(), packet.lookup_key.dst_port));
+            return Some(dst_protocol.unwrap());
         }
 
         let (ip, _, port) = Self::get_ip_epc_port(packet, false);
@@ -203,14 +203,14 @@ impl AppTable {
         };
         if src_protocol.is_some() && src_protocol.unwrap().get_l7_protocol() != L7Protocol::Unknown
         {
-            return Some((src_protocol.unwrap(), packet.lookup_key.src_port));
+            return Some(src_protocol.unwrap());
         }
         if src_protocol.is_none() && dst_protocol.is_none() {
             return None;
         } else if src_protocol.is_none() {
-            return Some((dst_protocol.unwrap(), packet.lookup_key.dst_port));
+            return Some(dst_protocol.unwrap());
         }
-        return Some((src_protocol.unwrap(), packet.lookup_key.src_port));
+        return Some(src_protocol.unwrap());
     }
 
     fn set_ipv4_protocol(


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the ebpf http log lacks response data #20002
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- When initializing flow, if it is ebpf data, obtain l7_proto_enum from app_table.get_protocol_from_ebpf()
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.