### PR TITLE
[Agent] Fix the ebpf http log lacks response data #20002

### DIFF
--- a/agent/src/flow_generator/app_table.rs
+++ b/agent/src/flow_generator/app_table.rs
@@ -171,7 +171,7 @@ impl AppTable {
         packet: &MetaPacket,
         local_epc: i32,
         remote_epc: i32,
-    ) -> Option<(L7ProtocolEnum, u16)> {
+    ) -> Option<L7ProtocolEnum> {
         if packet.lookup_key.is_loopback_packet() {
             return None;
         }
@@ -188,7 +188,7 @@ impl AppTable {
         };
         if dst_protocol.is_some() && dst_protocol.unwrap().get_l7_protocol() != L7Protocol::Unknown
         {
-            return Some((dst_protocol.unwrap(), packet.lookup_key.dst_port));
+            return Some(dst_protocol.unwrap());
         }
 
         let (ip, _, port) = Self::get_ip_epc_port(packet, false);
@@ -203,14 +203,14 @@ impl AppTable {
         };
         if src_protocol.is_some() && src_protocol.unwrap().get_l7_protocol() != L7Protocol::Unknown
         {
-            return Some((src_protocol.unwrap(), packet.lookup_key.src_port));
+            return Some(src_protocol.unwrap());
         }
         if src_protocol.is_none() && dst_protocol.is_none() {
             return None;
         } else if src_protocol.is_none() {
-            return Some((dst_protocol.unwrap(), packet.lookup_key.dst_port));
+            return Some(dst_protocol.unwrap());
         }
-        return Some((src_protocol.unwrap(), packet.lookup_key.src_port));
+        return Some(src_protocol.unwrap());
     }
 
     fn set_ipv4_protocol(

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -295,14 +295,14 @@ impl FlowMap {
         if !self.inject_flush_ticker(meta_packet.lookup_key.timestamp) {
             // 补充由于超时导致未查询策略，用于其它流程（如PCAP存储）
             #[cfg(target_os = "linux")]
-            let local_ecp_id = if self.ebpf_config.is_some() {
+            let local_epc_id = if self.ebpf_config.is_some() {
                 self.ebpf_config.as_ref().unwrap().load().epc_id as i32
             } else {
                 0
             };
             #[cfg(target_os = "windows")]
-            let local_ecp_id = 0;
-            (self.policy_getter).lookup(meta_packet, self.id as usize, local_ecp_id);
+            let local_epc_id = 0;
+            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
             return;
         }
 
@@ -820,16 +820,16 @@ impl FlowMap {
             residual_request: 0,
         };
         #[cfg(target_os = "linux")]
-        let local_ecp_id = if self.ebpf_config.is_some() {
+        let local_epc_id = if self.ebpf_config.is_some() {
             self.ebpf_config.as_ref().unwrap().load().epc_id as i32
         } else {
             0
         };
         #[cfg(target_os = "windows")]
-        let local_ecp_id = 0;
+        let local_epc_id = 0;
 
         // 标签
-        (self.policy_getter).lookup(meta_packet, self.id as usize, local_ecp_id);
+        (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
         self.update_endpoint_and_policy_data(&mut node, meta_packet);
 
         if let Some(endpoints) = &meta_packet.endpoint_data {
@@ -843,7 +843,18 @@ impl FlowMap {
             }
         }
 
-        let l7_proto_enum = self.app_table.get_protocol(meta_packet);
+        let l7_proto_enum = match meta_packet.signal_source {
+            SignalSource::EBPF => {
+                let (local_epc, remote_epc) = if meta_packet.lookup_key.l2_end_0 {
+                    (local_epc_id, 0)
+                } else {
+                    (0, local_epc_id)
+                };
+                self.app_table
+                    .get_protocol_from_ebpf(meta_packet, local_epc, remote_epc)
+            }
+            _ => self.app_table.get_protocol(meta_packet),
+        };
 
         if config.collector_enabled {
             node.meta_flow_perf = FlowPerf::new(
@@ -887,14 +898,14 @@ impl FlowMap {
         if !node.policy_in_tick[meta_packet.direction as usize] {
             node.policy_in_tick[meta_packet.direction as usize] = true;
             #[cfg(target_os = "linux")]
-            let local_ecp_id = if self.ebpf_config.is_some() {
+            let local_epc_id = if self.ebpf_config.is_some() {
                 self.ebpf_config.as_ref().unwrap().load().epc_id as i32
             } else {
                 0
             };
             #[cfg(target_os = "windows")]
-            let local_ecp_id = 0;
-            (self.policy_getter).lookup(meta_packet, self.id as usize, local_ecp_id);
+            let local_epc_id = 0;
+            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
             self.update_endpoint_and_policy_data(node, meta_packet);
 
             if let Some(endpoints) = &meta_packet.endpoint_data {
@@ -979,15 +990,15 @@ impl FlowMap {
         // 这里需要查询策略，建立ARP表
         if meta_packet.is_ndp_response() {
             #[cfg(target_os = "linux")]
-            let local_ecp_id = if self.ebpf_config.is_some() {
+            let local_epc_id = if self.ebpf_config.is_some() {
                 self.ebpf_config.as_ref().unwrap().load().epc_id as i32
             } else {
                 0
             };
             #[cfg(target_os = "windows")]
-            let local_ecp_id = 0;
+            let local_epc_id = 0;
 
-            (self.policy_getter).lookup(meta_packet, self.id as usize, local_ecp_id);
+            (self.policy_getter).lookup(meta_packet, self.id as usize, local_epc_id);
         }
     }
 
@@ -1002,6 +1013,19 @@ impl FlowMap {
         let mut info = None;
         if let Some(perf) = node.meta_flow_perf.as_mut() {
             let flow_id = node.tagged_flow.flow.flow_id;
+            #[cfg(target_os = "linux")]
+            let local_epc_id = if self.ebpf_config.is_some() {
+                self.ebpf_config.as_ref().unwrap().load().epc_id as i32
+            } else {
+                0
+            };
+            #[cfg(target_os = "windows")]
+            let local_epc_id = 0;
+            let (local_epc, remote_epc) = if meta_packet.lookup_key.l2_end_0 {
+                (local_epc_id, 0)
+            } else {
+                (0, local_epc_id)
+            };
             match perf.parse(
                 meta_packet,
                 is_first_packet_direction,
@@ -1011,6 +1035,8 @@ impl FlowMap {
                 Self::l7_metrics_enabled(config),
                 Self::l7_log_parse_enabled(config, &meta_packet.lookup_key),
                 &mut self.app_table,
+                local_epc,
+                remote_epc,
             ) {
                 Ok(i) => {
                     info = Some(i);


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes the ebpf http log lacks response data #20002
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- When initializing flow, if it is ebpf data, obtain l7_proto_enum from app_table.get_protocol_from_ebpf()
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
