### PR TITLE
Fixes some fields of the postgres L7PerfStats are empty #20065

### DIFF
--- a/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/krpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/krpc.rs
@@ -316,17 +316,19 @@ impl L7FlowPerf for KrpcLog {
         return self.perf_stats.is_some();
     }
 
-    fn copy_and_reset_data(&mut self, _l7_timeout_count: u32) -> FlowPerfStats {
+    fn copy_and_reset_data(&mut self, l7_timeout_count: u32) -> FlowPerfStats {
         FlowPerfStats {
             l7_protocol: L7Protocol::ProtobufRPC,
             l7: if let Some(perf) = self.perf_stats.take() {
                 L7PerfStats {
                     request_count: perf.req_count,
                     response_count: perf.resp_count,
+                    err_client_count: perf.req_err_count,
+                    err_server_count: perf.resp_err_count,
+                    err_timeout: l7_timeout_count,
                     rrt_count: perf.rrt_count,
                     rrt_sum: perf.rrt_sum.as_micros() as u64,
                     rrt_max: perf.rrt_max.as_micros() as u32,
-                    ..Default::default()
                 }
             } else {
                 L7PerfStats::default()

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -420,17 +420,19 @@ impl L7FlowPerf for SofaRpcLog {
         self.perf_stats.is_some()
     }
 
-    fn copy_and_reset_data(&mut self, _: u32) -> crate::common::flow::FlowPerfStats {
+    fn copy_and_reset_data(&mut self, timeout_count: u32) -> crate::common::flow::FlowPerfStats {
         FlowPerfStats {
             l7_protocol: L7Protocol::SofaRPC,
             l7: if let Some(perf) = self.perf_stats.take() {
                 L7PerfStats {
                     request_count: perf.req_count,
                     response_count: perf.resp_count,
+                    err_client_count: perf.req_err_count,
+                    err_server_count: perf.resp_err_count,
+                    err_timeout: timeout_count,
                     rrt_count: perf.rrt_count,
                     rrt_sum: perf.rrt_sum.as_micros() as u64,
                     rrt_max: perf.rrt_max.as_micros() as u32,
-                    ..Default::default()
                 }
             } else {
                 L7PerfStats::default()

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -259,17 +259,19 @@ impl L7FlowPerf for PostgresqlLog {
         return self.perf_stats.is_some();
     }
 
-    fn copy_and_reset_data(&mut self, _l7_timeout_count: u32) -> FlowPerfStats {
+    fn copy_and_reset_data(&mut self, l7_timeout_count: u32) -> FlowPerfStats {
         FlowPerfStats {
             l7_protocol: L7Protocol::PostgreSQL,
             l7: if let Some(perf) = self.perf_stats.take() {
                 L7PerfStats {
                     request_count: perf.req_count,
                     response_count: perf.resp_count,
+                    err_client_count: perf.req_err_count,
+                    err_server_count: perf.resp_err_count,
+                    err_timeout: l7_timeout_count,
                     rrt_count: perf.rrt_count,
                     rrt_sum: perf.rrt_sum.as_micros() as u64,
                     rrt_max: perf.rrt_max.as_micros() as u32,
-                    ..Default::default()
                 }
             } else {
                 L7PerfStats::default()


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes some fields of the postgres L7PerfStats are empty #20065
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- 
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.