### PR TITLE
[Agent] Fix wrong doc code

### DIFF
--- a/agent/src/collector/collector.rs
+++ b/agent/src/collector/collector.rs
@@ -638,6 +638,7 @@ impl Stash {
             code: {
                 let mut code = Code::IP
                     | Code::L3_EPC_ID
+                    | Code::GPID
                     | Code::VTAP_ID
                     | Code::PROTOCOL
                     | Code::SERVER_PORT
@@ -785,6 +786,7 @@ impl Stash {
             code: {
                 let mut code = Code::IP_PATH
                     | Code::L3_EPC_PATH
+                    | Code::GPID_PATH
                     | Code::VTAP_ID
                     | Code::PROTOCOL
                     | Code::SERVER_PORT
@@ -1016,6 +1018,7 @@ mod tests {
             direction: Direction::ClientToServer,
             code: Code::IP
                 | Code::L3_EPC_ID
+                | Code::GPID
                 | Code::VTAP_ID
                 | Code::PROTOCOL
                 | Code::SERVER_PORT
@@ -1046,6 +1049,7 @@ mod tests {
 
         tagger.code = Code::IP_PATH
             | Code::L3_EPC_PATH
+            | Code::GPID_PATH
             | Code::VTAP_ID
             | Code::PROTOCOL
             | Code::SERVER_PORT


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes wrong doc code
#### Steps to reproduce the bug

- PR: https://github.com/deepflowys/deepflow/pull/2116

panic:
```
thread 'collector' panicked at '没有符合，需要更新tagger.code: IP_PATH | L3_EPC_PATH | DIRECTION | PROTOCOL | SERVER_PORT | TAP_TYPE | VTAP_ID | TAP_PORT', src/collector/collector.rs:292:18
stack backtrace:
   0: rust_begin_unwind
             at ./rustc/897e37553bba8b42751c67658967889d11ecd120/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at ./rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:142:14
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

#### Changes to fix the bug
- fix doc code
#### Affected branches
- main

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
