### PR TITLE
[Agent] fix ebpf dispatcher's vtap_id is not updated #20107

### DIFF
--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -196,14 +196,6 @@ struct EbpfDispatcher {
 impl EbpfDispatcher {
     const FLOW_MAP_SIZE: usize = 1 << 14;
 
-    fn on_config_change(&mut self, config: &EbpfConfig) {
-        info!(
-            "ebpf collector config change from {:#?} to {:#?}.",
-            *self.config.load(),
-            config
-        );
-    }
-
     fn run(&mut self, sync_counter: SyncEbpfCounter) {
         let mut flow_map = FlowMap::new(
             self.dispatcher_id as u32,
@@ -504,13 +496,16 @@ impl EbpfCollector {
 
     pub fn on_config_change(&mut self, config: &EbpfConfig) {
         if config.l7_log_enabled() {
+            unsafe {
+                if SWITCH {
+                    self.stop();
+                }
+            }
             self.start();
+            Self::ebpf_on_config_change(config.l7_log_packet_size);
         } else {
             self.stop();
         }
-
-        Self::ebpf_on_config_change(config.l7_log_packet_size);
-        self.thread_dispatcher.on_config_change(config);
     }
 
     pub fn start(&mut self) {


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes ebpf dispatcher's vtap_id is not updated and add windows memory limit #20107
#### Steps to reproduce the bug
- 
#### Changes to fix the bug
- Restart the ebpf_dispatcher when the ebpf_config is updated
- Add windows memory limit
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.