### PR TITLE
[Agent] fix sql check not handle single word

### DIFF
--- a/agent/src/flow_generator/protocol_logs/sql/sql_check.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/sql_check.rs
@@ -111,11 +111,13 @@ pub(super) fn is_postgresql(sql: &String) -> bool {
     LOAD
     FETCH
     IMPORT
+    DESC
 */
 
 // not all of sql start first keyword. only log some necessary sql.
-const MYSQL_START: [&'static str; 10] = [
-    "XA", "FLUSH", "SHOW", "USE", "LOCK", "UNLOCK", "STOP", "START", "LOAD", "ANALYZE",
+const MYSQL_START: [&'static str; 14] = [
+    "XA", "FLUSH", "SHOW", "USE", "LOCK", "UNLOCK", "STOP", "START", "LOAD", "ANALYZE", "BEGIN",
+    "COMMIT", "ROLLBACK", "DESC",
 ];
 
 pub(super) fn is_mysql(sql: &String) -> bool {
@@ -164,6 +166,9 @@ fn trim_head_comment_and_first_upper(mut sql: &str, first_word_max_len: usize) -
             let (sub_sql, _) = sql.split_at(idx);
             return Some(sub_sql.to_ascii_uppercase());
         }
+    } else if sql.len() <= first_word_max_len {
+        // if not have word boundary, assume as single word
+        return Some(sql.to_ascii_uppercase());
     }
     None
 }
@@ -209,7 +214,7 @@ mod test_sql_check {
         );
         assert_eq!(
             trim_head_comment_and_first_upper(r"/* unable to parse */SelecT", 6),
-            None
+            Some(String::from("SELECT"))
         );
         assert_eq!(
             trim_head_comment_and_first_upper(r"/* able to parse */SelecT ", 6),


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent
<!--
One or more of:
- Agent
- CLI
- Server
- Message
- Libs
- Documents
- Workflow
-->


### Fixes sql check fail when sql is single word 
#### Steps to reproduce the bug

#### Changes to fix the bug

#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.


<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
