### PR TITLE
[Server] add cen.vpc_ids to peer connection #20134

### DIFF
--- a/server/controller/trisolaris/metadata/db_data.go
+++ b/server/controller/trisolaris/metadata/db_data.go
@@ -67,6 +67,7 @@ type DBDataCache struct {
 	npbTunnels              []*models.NpbTunnel
 	npbPolicies             []*models.NpbPolicy
 	pcapPolicies            []*models.PcapPolicy
+	cens                    []*models.CEN
 }
 
 func newDBDataCache() *DBDataCache {
@@ -240,6 +241,10 @@ func (d *DBDataCache) GetNpbPolicies() []*models.NpbPolicy {
 
 func (d *DBDataCache) GetPcapPolicies() []*models.PcapPolicy {
 	return d.pcapPolicies
+}
+
+func (d *DBDataCache) GetCENs() []*models.CEN {
+	return d.cens
 }
 
 func GetTapTypesFromDB(db *gorm.DB) []*models.TapType {
@@ -538,6 +543,13 @@ func (d *DBDataCache) GetDataCacheFromDB(db *gorm.DB) {
 	pcapPolicies, err := dbmgr.DBMgr[models.PcapPolicy](db).GetBatchFromState(ACL_STATE_ENABLE)
 	if err == nil {
 		d.pcapPolicies = pcapPolicies
+	} else {
+		log.Error(err)
+	}
+
+	cens, err := dbmgr.DBMgr[models.CEN](db).Gets()
+	if err == nil {
+		d.cens = cens
 	} else {
 		log.Error(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server
 
### Add CEN(Cloud Enterprise Network) data to peer connection, associate cen.vpc_ids in pairs in one direction.
#### Affected branches
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
