### PR TITLE
[eBPF] Dump ebpf data to file #20159

### DIFF
--- a/agent/src/ebpf/Makefile
+++ b/agent/src/ebpf/Makefile
@@ -55,7 +55,7 @@ OBJS := user/elf.o \
 	user/offset.o
 
 STATIC_OBJS := $(addprefix $(STATIC_OBJDIR)/,$(OBJS))
-CFLAGS ?= -std=gnu99 -g -O2 -ffunction-sections -fdata-sections -fPIC -fno-omit-frame-pointer -Wall -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
+CFLAGS ?= -std=gnu99 -g -O2 -ffunction-sections -fdata-sections -fPIC -fno-omit-frame-pointer -Wall -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-parameter -Wno-missing-field-initializers
 # '-Wformat-truncation' : The warning was added in gcc7.1
 GCC_VER_GTE71 := $(shell echo `gcc --version | grep ^gcc | cut -f3 -d' '|cut -f1-2 -d.` \>= 7.1 | sed -e 's/\./*100+/g' | bc )
 ifeq ($(GCC_VER_GTE71),1)

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -31,9 +31,11 @@
 #include <linux/unistd.h>
 #include <unistd.h>
 #include <time.h>
+#include <sys/time.h>
 #include <string.h>
 #include <inttypes.h>
 #include <sys/utsname.h>
+#include "config.h"
 #include "list.h"
 #include "common.h"
 #include "log.h"
@@ -486,4 +488,40 @@ bool is_process(int pid)
 		return true;
 
 	return false;
+}
+
+static char *gen_datetime_str(const char *fmt)
+{
+	const int strlen = DATADUMP_FILE_PATH_SIZE;
+	time_t timep;
+	char *str;
+	struct tm *p;
+	str = malloc(strlen);
+	if (str == NULL) {
+		ebpf_warning("malloc() failed.\n");
+		return NULL;
+	}
+
+	time(&timep);
+	p = localtime(&timep);
+	struct timeval msectime;
+	gettimeofday(&msectime, NULL);
+	long msec = 0;
+	msec = msectime.tv_usec / 1000;
+	snprintf(str, strlen, fmt,
+		 (1900 + p->tm_year), (1 + p->tm_mon),
+		 p->tm_mday, p->tm_hour, p->tm_min,
+		 p->tm_sec, msec);
+
+	return str;
+}
+
+char *gen_file_name_by_datetime(void)
+{
+	return gen_datetime_str("%d_%02d_%02d_%02d_%02d_%02d_%ld");
+}
+
+char *gen_timestamp_prefix(void)
+{
+	return gen_datetime_str("%d-%02d-%02d %02d:%02d:%02d.%ld");
 }

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -264,5 +264,7 @@ int get_num_possible_cpus(void);
 // Check if task is the main thread based on pid.
 // Ignore threads other than the main thread in uprobe to avoid repeating hooks
 bool is_process(int pid);
+char *gen_file_name_by_datetime(void);
+char *gen_timestamp_prefix(void);
 
 #endif /* DF_COMMON_H */

--- a/agent/src/ebpf/user/config.h
+++ b/agent/src/ebpf/user/config.h
@@ -64,4 +64,14 @@
 // execute/exit events delayed processing time, unit: second
 #define PROC_EVENT_DELAY_HANDLE_DEF     60
 
+#define SK_TRACER_NAME			"socket-trace"
+
+#define DATADUMP_FILE_PATH_SIZE		1024
+#define DATADUMP_FILE_PATH_PREFIX	"/var/log"
+
+// trace map回收的最大比例（指当前数量超过了整个MAP的容量的回收比例才进行回收）
+// Maximum proportion of trace map reclamation (refers to the proportion of
+// reclamation when the current quantity exceeds the capacity of the whole MAP)
+#define RECLAIM_TRACE_MAP_SCALE		0.9
+
 #endif /* DF_EBPF_CONFIG_H */

--- a/agent/src/ebpf/user/ctrl.c
+++ b/agent/src/ebpf/user/ctrl.c
@@ -61,16 +61,16 @@ int sockopt_register(struct tracer_sockopts *sockopts)
 
 	if (sockopts_exist(sockopts)) {
 		ebpf_info("%s: socket msg type already exist\n", __func__);
-		ebpf_info("sockopt type already exist ->\n"
-			  "\t\tget: %d - %d\n\t\tset: %d - %d\n",
+		ebpf_info("sockopt type already exist "
+			  "get: %d - %d set: %d - %d\n",
 			  sockopts->get_opt_min, sockopts->get_opt_max,
 			  sockopts->set_opt_min, sockopts->set_opt_max);
 
 		return ETR_EXIST;
 	}
 
-	ebpf_info("sockopt register succeed, type ->\n"
-		  "\t\tget: %d - %d\n\t\tset: %d - %d\n",
+	ebpf_info("sockopt register succeed, type "
+		  "get: %d - %d set: %d - %d\n",
 		  sockopts->get_opt_min, sockopts->get_opt_max,
 		  sockopts->set_opt_min, sockopts->set_opt_max);
 

--- a/agent/src/ebpf/user/ctrl.h
+++ b/agent/src/ebpf/user/ctrl.h
@@ -75,6 +75,16 @@ struct tracer_sock_msg_reply {
 	char data[0];
 };
 
+struct datadump_msg {
+	bool enable;		// Whether to enable the datadump ?
+	bool is_params;		// Is it set pid or comm ?
+	bool only_stdout;	// Whether to dump data to stdout ?
+	int timeout;
+	int pid;
+	uint8_t proto;
+	char comm[16];
+};
+
 int sockopt_ctl(void *arg);
 int ctrl_init(void);
 int sockopt_register(struct tracer_sockopts *sockopts);

--- a/agent/src/ebpf/user/ctrl_tracer.c
+++ b/agent/src/ebpf/user/ctrl_tracer.c
@@ -21,89 +21,94 @@
 #include "tracer.h"
 #include "socket.h"
 
-#define MFBPF_NAME           "deepflow-ebpfctl"
-#define MFBPF_VERSION        "v1.0.0"
-#define LINUX_VER_LEN        128
+#define DF_BPF_NAME           "deepflow-ebpfctl"
+#define DF_BPF_VERSION        "v1.0.0"
+#define LINUX_VER_LEN         128
 
-typedef enum mfbpf_cmd_e {
-	MFBPF_CMD_ADD,
-	MFBPF_CMD_DEL,
-	MFBPF_CMD_SET,
-	MFBPF_CMD_SHOW,
-	MFBPF_CMD_REPLACE,
-	MFBPF_CMD_FLUSH,
-	MFBPF_CMD_HELP,
-} mfbpf_cmd_t;
+typedef enum df_bpf_cmd_e {
+	DF_BPF_CMD_ADD,
+	DF_BPF_CMD_DEL,
+	DF_BPF_CMD_SET,
+	DF_BPF_CMD_ON,
+	DF_BPF_CMD_OFF,
+	DF_BPF_CMD_SHOW,
+	DF_BPF_CMD_REPLACE,
+	DF_BPF_CMD_FLUSH,
+	DF_BPF_CMD_HELP,
+} df_bpf_cmd_t;
 
-struct mfbpf_conf {
+struct df_bpf_conf {
 	int af;
 	int verbose;
 	int stats;
 	int interval;
 	int count;
+	int timeout;
 	bool color;
+	bool only_stdout;
 	char *obj;
-	mfbpf_cmd_t cmd;
+	df_bpf_cmd_t cmd;
 	int argc;
 	char **argv;
 };
 
-struct mfbpf_obj {
+struct df_bpf_obj {
 	char *name;
 	void *param;
 
 	void (*help) (void);
 	/* @conf is used to passing general config like af, verbose, ...
 	 * we have obj.parse() to handle obj specific parameters. */
-	int (*do_cmd) (struct mfbpf_obj * obj, mfbpf_cmd_t cmd,
-		       struct mfbpf_conf * conf);
+	int (*do_cmd) (struct df_bpf_obj * obj, df_bpf_cmd_t cmd,
+		       struct df_bpf_conf * conf);
 	/* the parser can be used to parse @conf into @param */
-	int (*parse) (struct mfbpf_obj * obj, struct mfbpf_conf * conf);
-	int (*check) (const struct mfbpf_obj * obj, mfbpf_cmd_t cmd);
+	int (*parse) (struct df_bpf_obj * obj, struct df_bpf_conf * conf);
+	int (*check) (const struct df_bpf_obj * obj, df_bpf_cmd_t cmd);
 };
 
 static void tracer_help(void)
 {
-	fprintf(stderr, "Usage:\n" "    %s tracer show\n", MFBPF_NAME);
+	fprintf(stderr, "Usage:\n" "    %s tracer show\n", DF_BPF_NAME);
 }
 
 static void socktrace_help(void)
 {
-	fprintf(stderr, "Usage:\n" "    %s tracer show\n", MFBPF_NAME);
+	fprintf(stderr, "Usage:\n" "    %s tracer show\n", DF_BPF_NAME);
 }
 
-static inline char *get_proto_name(uint16_t proto_id)
+static void datadump_help(void)
 {
-	switch (proto_id) {
-	case PROTO_HTTP1:
-		return "HTTP";
-	case PROTO_HTTP2:
-		return "HTTP2";
-	case PROTO_TLS_HTTP1:
-		return "TLS_HTTP1";
-	case PROTO_TLS_HTTP2:
-		return "TLS_HTTP2";
-	case PROTO_MYSQL:
-		return "MySQL";
-	case PROTO_DNS:
-		return "DNS";
-	case PROTO_REDIS:
-		return "Redis";
-	case PROTO_KAFKA:
-		return "Kafka";
-	case PROTO_MQTT:
-		return "MQTT";
-	case PROTO_DUBBO:
-		return "Dubbo";
-	case PROTO_SOFARPC:
-		return "SofaRPC";
-	case PROTO_POSTGRESQL:
-		return "PgSQL";
-	default:
-		return "Unknown";
-	}
-
-	return "Unknown";
+	fprintf(stderr, "Usage:\n" "    %s datadump {on|off} [OPTIONS]\n", DF_BPF_NAME);
+	fprintf(stderr, "    %s datadump set pid PID comm COMM proto PROTO_NUM\n", DF_BPF_NAME);
+	fprintf(stderr, "PROTO_NUM:\n");
+	fprintf(stderr, "    0:   PROTO_ALL\n");
+	fprintf(stderr, "    1:   PROTO_ORTHER\n");
+	fprintf(stderr, "    20:  PROTO_HTTP1\n");
+	fprintf(stderr, "    21:  PROTO_HTTP2\n");
+	fprintf(stderr, "    22:  PROTO_TLS_HTTP1\n");
+	fprintf(stderr, "    23:  PROTO_TLS_HTTP2\n");
+	fprintf(stderr, "    40:  PROTO_DUBBO\n");
+	fprintf(stderr, "    43:  PROTO_SOFARPC\n");
+	fprintf(stderr, "    60:  PROTO_MYSQL\n");
+	fprintf(stderr, "    61:  PROTO_POSTGRESQL\n");
+	fprintf(stderr, "    80:  PROTO_REDIS\n");
+	fprintf(stderr, "    100: PROTO_KAFKA\n");
+	fprintf(stderr, "    101: PROTO_MQTT\n");
+	fprintf(stderr, "    120: PROTO_DNS\n");
+	fprintf(stderr, "PID:\n");
+	fprintf(stderr, "    0:   all process/thread\n");
+	fprintf(stderr, "COMM:\n");
+	fprintf(stderr, "    '':  The process name or thread name is not restricted.\n");
+	fprintf(stderr, "Options:\n");
+	fprintf(stderr, "    '-O, --only-stdout':  dump to stdout only.\n");
+	fprintf(stderr, "    '-t, --timeout':      set datadump timout. Unit: second\n");
+	fprintf(stderr, "For example:\n");
+	fprintf(stderr, "    %s datadump set pid 4567 comm curl proto 0\n",
+		DF_BPF_NAME);
+	fprintf(stderr, "    %s datadump set pid 4567 comm '' proto 20\n", DF_BPF_NAME);
+	fprintf(stderr, "    %s datadump on --timeout 60\n", DF_BPF_NAME);
+	fprintf(stderr, "    %s datadump on --only-stdout --timeout 60\n", DF_BPF_NAME);
+	fprintf(stderr, "    %s datadump off\n", DF_BPF_NAME);
 }
 
 static void tracer_dump(struct bpf_tracer_param *param)
@@ -132,8 +137,9 @@ static void tracer_dump(struct bpf_tracer_param *param)
 		    ("worker %d for queue, de %" PRIu64 " en %" PRIu64 " lost %"
 		     PRIu64 " alloc failed %" PRIu64 " burst %" PRIu64
 		     " queue size %u cap %u\n", j, rx_q->dequeue_nr,
-		     rx_q->enqueue_nr, rx_q->enqueue_lost, rx_q->heap_get_failed,
-		     rx_q->burst_count, rx_q->queue_size, rx_q->ring_capacity);
+		     rx_q->enqueue_nr, rx_q->enqueue_lost,
+		     rx_q->heap_get_failed, rx_q->burst_count, rx_q->queue_size,
+		     rx_q->ring_capacity);
 		heap_get_failed += rx_q->heap_get_failed;
 		dequeue_nr += rx_q->dequeue_nr;
 		enqueue_nr += rx_q->enqueue_nr;
@@ -153,8 +159,7 @@ static void tracer_dump(struct bpf_tracer_param *param)
 		if (btp->proto_status[j] > 0) {
 			printf("- %-10s(%d) %" PRIu64 "\n",
 			       get_proto_name((uint16_t) j),
-			       j,
-			       btp->proto_status[j]);
+			       j, btp->proto_status[j]);
 		}
 	}
 
@@ -282,22 +287,14 @@ static inline int msg_recv(int clt_fd, struct tracer_sock_msg_reply *reply_hdr,
 	return 0;
 }
 
-int mfbpf_getsockopt(sockoptid_t cmd, const void *in, size_t in_len,
-		     void **out, size_t * out_len)
+static int sockopt_send(enum sockopt_type type, sockoptid_t cmd, const void *in,
+			size_t in_len)
 {
 	struct tracer_sock_msg *msg;
-	struct tracer_sock_msg_reply reply_hdr;
 	struct sockaddr_un clt_addr;
 	int clt_fd;
 	int res;
 	size_t msg_len;
-
-	if (NULL == out || NULL == out_len) {
-		fprintf(stderr, "[%s] no pointer for info return\n", __func__);
-		return -1;
-	}
-	*out = NULL;
-	*out_len = 0;
 
 	memset(&clt_addr, 0, sizeof(struct sockaddr_un));
 	clt_addr.sun_family = AF_UNIX;
@@ -323,7 +320,7 @@ int mfbpf_getsockopt(sockoptid_t cmd, const void *in, size_t in_len,
 	memset(msg, 0, msg_len);
 	msg->version = SOCKOPT_VERSION;
 	msg->id = cmd;
-	msg->type = SOCKOPT_GET;
+	msg->type = type;
 	msg->len = in_len;
 	res = msg_send(clt_fd, msg, in, in_len);
 
@@ -332,13 +329,32 @@ int mfbpf_getsockopt(sockoptid_t cmd, const void *in, size_t in_len,
 
 	if (res) {
 		close(clt_fd);
-		return res;
+		return -1;
 	}
 
+	return clt_fd;
+}
+
+int df_bpf_getsockopt(sockoptid_t cmd, const void *in, size_t in_len,
+		      void **out, size_t * out_len)
+{
+	struct tracer_sock_msg_reply reply_hdr;
+	int clt_fd, res;
+
+	if (NULL == out || NULL == out_len) {
+		fprintf(stderr, "[%s] no pointer for info return\n", __func__);
+		return -1;
+	}
+	*out = NULL;
+	*out_len = 0;
+
+	if ((clt_fd = sockopt_send(SOCKOPT_GET, cmd, in, in_len)) <= 0) {
+		return -1;
+	}
 	res = msg_recv(clt_fd, &reply_hdr, out, out_len);
 	if (res) {
 		close(clt_fd);
-		return res;
+		return -1;
 	}
 
 	if (reply_hdr.errcode) {
@@ -352,7 +368,32 @@ int mfbpf_getsockopt(sockoptid_t cmd, const void *in, size_t in_len,
 	return 0;
 }
 
-static inline void mfbpf_sockopt_msg_free(void *msg)
+int df_bpf_setsockopt(sockoptid_t cmd, const void *in, size_t in_len)
+{
+	struct tracer_sock_msg_reply reply_hdr;
+	int clt_fd, res;
+	if ((clt_fd = sockopt_send(SOCKOPT_SET, cmd, in, in_len)) <= 0) {
+		return -1;
+	}
+
+	res = msg_recv(clt_fd, &reply_hdr, NULL, NULL);
+	if (res) {
+		close(clt_fd);
+		return -1;
+	}
+
+	if (reply_hdr.errcode) {
+		fprintf(stderr, "[%s] Server error: %s\n", __func__,
+			reply_hdr.errstr);
+		close(clt_fd);
+		return reply_hdr.errcode;
+	}
+
+	close(clt_fd);
+	return 0;
+}
+
+static inline void df_bpf_sockopt_msg_free(void *msg)
 {
 	free(msg);
 	msg = NULL;
@@ -365,8 +406,8 @@ static inline void get_kernel_version(char *buf)
 	snprintf(buf, LINUX_VER_LEN, "Linux %d.%d.%d\n", major, minor, patch);
 }
 
-static int socktrace_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
-			    struct mfbpf_conf *conf)
+static int socktrace_do_cmd(struct df_bpf_obj *obj, df_bpf_cmd_t cmd,
+			    struct df_bpf_conf *conf)
 {
 	struct bpf_socktrace_params *sk_trace_params = NULL;
 	struct bpf_offset_param_array *array = NULL;
@@ -378,10 +419,10 @@ static int socktrace_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
 	printf("\n\033[0;33;mLinux Version: %s\033[0m\n", linux_ver_str);
 
 	switch (conf->cmd) {
-	case MFBPF_CMD_SHOW:
+	case DF_BPF_CMD_SHOW:
 		err =
-		    mfbpf_getsockopt(SOCKOPT_GET_SOCKTRACE_SHOW, NULL,
-				     0, (void **)&sk_trace_params, &size);
+		    df_bpf_getsockopt(SOCKOPT_GET_SOCKTRACE_SHOW, NULL,
+				      0, (void **)&sk_trace_params, &size);
 		if (err != 0)
 			return err;
 
@@ -394,7 +435,7 @@ static int socktrace_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
 		    || size != sizeof(*sk_trace_params) +
 		    array->count * sizeof(struct bpf_offset_param)) {
 			fprintf(stderr, "corrupted response.\n");
-			mfbpf_sockopt_msg_free(sk_trace_params);
+			df_bpf_sockopt_msg_free(sk_trace_params);
 			return ETR_INVAL;
 		}
 
@@ -404,8 +445,19 @@ static int socktrace_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
 		       sk_trace_params->kern_socket_map_used);
 		printf("kern_trace_map_max:\t%u\n",
 		       sk_trace_params->kern_trace_map_max);
-		printf("kern_trace_map_used:\t%u\n\n",
+		printf("kern_trace_map_used:\t%u\n",
 		       sk_trace_params->kern_trace_map_used);
+		printf("datadump_enable:\t%s\n",
+		       sk_trace_params->datadump_enable ? "true" : "false");
+		printf("datadump_pid:\t%d\n",
+		       sk_trace_params->datadump_pid);
+		printf("datadump_proto:\t%d\n",
+		       sk_trace_params->datadump_proto);
+		printf("datadump_comm:\t%s\n",
+		       sk_trace_params->datadump_comm);
+		printf("datadump_file_path:\t%s\n\n",
+		       sk_trace_params->datadump_file_path);
+
 		printf
 		    ("tracer_state:\t%u [ 0 (TRACER_INIT), 1 (TRACER_RUNNING), "
 		     "2 (TRACER_STOP) ]\n\n", sk_trace_params->tracer_state);
@@ -419,25 +471,113 @@ static int socktrace_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
 
 		offset_dump(i - 1, &array->offsets[i - 1]);
 
-		mfbpf_sockopt_msg_free(sk_trace_params);
+		df_bpf_sockopt_msg_free(sk_trace_params);
 		return ETR_OK;
 	default:
 		return ETR_NOTSUPP;
 	}
 }
 
-static int tracer_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
-			 struct mfbpf_conf *conf)
+static int datadump_do_cmd(struct df_bpf_obj *obj, df_bpf_cmd_t cmd,
+			   struct df_bpf_conf *conf)
+{
+	switch (conf->cmd) {
+	case DF_BPF_CMD_ON:
+	case DF_BPF_CMD_OFF:
+	case DF_BPF_CMD_SET:
+		{
+			struct datadump_msg msg;
+			memset(msg.comm, 0, sizeof(msg.comm));
+			msg.is_params = false;
+			msg.only_stdout = conf->only_stdout;
+			msg.timeout = conf->timeout;
+			if (conf->cmd == DF_BPF_CMD_ON
+			    || conf->cmd == DF_BPF_CMD_OFF) {
+				if (conf->argc != 0) {
+					obj->help();
+					return ETR_NOTSUPP;
+				}
+				if (conf->cmd == DF_BPF_CMD_ON) {
+					msg.enable = true;
+					if (msg.timeout == 0) {
+						printf("Miss --timeout setting.\n");
+						return ETR_NOTSUPP;
+					}
+					printf("Set datadump on, timeout %ds ",
+					       msg.timeout);
+				} else {
+					msg.enable = false;
+					printf("Set datadump off ");
+				}
+			} else {
+				if (conf->argc != 6
+				    || strcmp(conf->argv[0], "pid")
+				    || strcmp(conf->argv[2], "comm")
+				    || strcmp(conf->argv[4], "proto")) {
+					obj->help();
+					return ETR_NOTSUPP;
+				}
+
+				if (conf->argv[1][0] == '0'
+				    && conf->argv[1][1] == '\0') {
+					msg.pid = 0;
+				} else {
+					msg.pid = atoi(conf->argv[1]);
+					if (msg.pid <= 0) {
+						obj->help();
+						return ETR_NOTSUPP;
+					}
+				}
+
+				if (conf->argv[5][0] == '0'
+				    && conf->argv[5][1] == '\0') {
+					msg.proto = 0;
+				} else {
+					msg.proto = atoi(conf->argv[5]);
+					if (msg.proto <= 0) {
+						obj->help();
+						return ETR_NOTSUPP;
+					}
+				}
+
+				msg.is_params = true;
+				memset(msg.comm, 0, sizeof(msg.comm));
+				if (strlen(conf->argv[3]) > 0) {
+					memcpy(msg.comm, conf->argv[3],
+					       sizeof(msg.comm) - 1);
+				}
+
+				printf("Set pid %d comm %s proto %d ", msg.pid,
+				       msg.comm, msg.proto);
+			}
+
+			if (df_bpf_setsockopt(SOCKOPT_SET_DATADUMP_ADD, &msg,
+					      sizeof(msg)) == 0) {
+				printf("Success.\n");
+			} else {
+				printf("Failed.\n");
+			}
+
+			break;
+		}
+	default:
+		return ETR_NOTSUPP;
+	}
+	return ETR_OK;
+}
+
+static int tracer_do_cmd(struct df_bpf_obj *obj, df_bpf_cmd_t cmd,
+			 struct df_bpf_conf *conf)
 {
 	struct bpf_tracer_param_array *array;
 	size_t size, i;
 	int err;
 
 	switch (conf->cmd) {
-	case MFBPF_CMD_SHOW:
+	case DF_BPF_CMD_SHOW:
 		err =
-		    mfbpf_getsockopt(SOCKOPT_GET_TRACER_SHOW, NULL,
-				     0, (void **)&array, &size);
+		    df_bpf_getsockopt(SOCKOPT_GET_TRACER_SHOW, NULL,
+				      0, (void **)&array, &size);
 		if (err != 0)
 			return err;
 
@@ -445,77 +585,89 @@ static int tracer_do_cmd(struct mfbpf_obj *obj, mfbpf_cmd_t cmd,
 		    || size != sizeof(*array) +
 		    array->count * sizeof(struct bpf_tracer_param)) {
 			fprintf(stderr, "corrupted response.\n");
-			mfbpf_sockopt_msg_free(array);
+			df_bpf_sockopt_msg_free(array);
 			return ETR_INVAL;
 		}
 
 		for (i = 0; i < array->count; i++)
 			tracer_dump(&array->tracers[i]);
 
-		mfbpf_sockopt_msg_free(array);
+		df_bpf_sockopt_msg_free(array);
 		return ETR_OK;
 	default:
 		return ETR_NOTSUPP;
 	}
 }
 
-struct mfbpf_obj tr_obj = {
+struct df_bpf_obj tr_obj = {
 	.name = "tracer",
 	.help = tracer_help,
 	.do_cmd = tracer_do_cmd,
 };
 
-struct mfbpf_obj socktrace_obj = {
+struct df_bpf_obj socktrace_obj = {
 	.name = "socktrace",
 	.help = socktrace_help,
 	.do_cmd = socktrace_do_cmd,
+};
+
+struct df_bpf_obj datadump_obj = {
+	.name = "datadump",
+	.help = datadump_help,
+	.do_cmd = datadump_do_cmd,
 };
 
 static void usage(void)
 {
 	fprintf(stderr,
 		"Usage:\n"
-		"    " MFBPF_NAME " [OPTIONS] OBJECT { COMMAND | help }\n"
+		"    " DF_BPF_NAME " [OPTIONS] OBJECT { COMMAND | help }\n"
 		"Parameters:\n"
-		"    OBJECT  := { tracer socktrace }\n"
-		"    COMMAND := { show list }\n"
+		"    OBJECT  := { tracer socktrace datadump }\n"
+		"    COMMAND := { show list set }\n"
 		"Options:\n"
 		"    -v, --verbose\n"
 		"    -h, --help\n" "    -V, --version\n" "    -C, --color\n");
 }
 
-static struct mfbpf_obj *mfbpf_obj_get(const char *name)
+static struct df_bpf_obj *df_bpf_obj_get(const char *name)
 {
 	if (strcmp(name, "tracer") == 0) {
 		return &tr_obj;
 	} else if (strcmp(name, "socktrace") == 0) {
 		return &socktrace_obj;
+	} else if (strcmp(name, "datadump") == 0) {
+		return &datadump_obj;
 	}
 
 	return NULL;
 }
 
-static int parse_args(int argc, char *argv[], struct mfbpf_conf *conf)
+static int parse_args(int argc, char *argv[], struct df_bpf_conf *conf)
 {
 	int opt;
-	struct mfbpf_obj *obj;
+	struct df_bpf_obj *obj;
 	struct option opts[] = {
 		{"verbose", no_argument, NULL, 'v'},
 		{"help", no_argument, NULL, 'h'},
 		{"version", no_argument, NULL, 'V'},
 		{"color", no_argument, NULL, 'C'},
+		{"only-stdout", no_argument, NULL, 'O'},
+		{"timeout", required_argument, NULL, 't'},
 		{NULL, 0, NULL, 0},
 	};
 
 	memset(conf, 0, sizeof(*conf));
 	conf->af = AF_UNSPEC;
+	conf->only_stdout = false;
+	conf->timeout = 0;
 
 	if (argc <= 1) {
 		usage();
 		exit(0);
 	}
 
-	while ((opt = getopt_long(argc, argv, "vhVC", opts, NULL)) != -1) {
+	while ((opt = getopt_long(argc, argv, "vhVCOt:", opts, NULL)) != -1) {
 		switch (opt) {
 		case 'v':
 			conf->verbose = 1;
@@ -524,10 +676,20 @@ static int parse_args(int argc, char *argv[], struct mfbpf_conf *conf)
 			usage();
 			exit(0);
 		case 'V':
-			printf(MFBPF_NAME "-" MFBPF_VERSION "\n");
+			printf(DF_BPF_NAME "-" DF_BPF_VERSION "\n");
 			exit(0);
 		case 'C':
 			conf->color = true;
+			break;
+		case 'O':
+			conf->only_stdout = true;
+			break;
+		case 't':
+			conf->timeout = atoi(optarg);
+			if (conf->timeout <= 0) {
+				fprintf(stderr, "Invalid option: --timeout");
+				return -1;
+			}
 			break;
 		case '?':
 		default:
@@ -547,7 +709,7 @@ static int parse_args(int argc, char *argv[], struct mfbpf_conf *conf)
 
 	conf->obj = argv[0];
 	if (argc < 2) {
-		obj = mfbpf_obj_get(conf->obj);
+		obj = df_bpf_obj_get(conf->obj);
 		if (obj && obj->help)
 			obj->help();
 		else
@@ -556,10 +718,19 @@ static int parse_args(int argc, char *argv[], struct mfbpf_conf *conf)
 	}
 
 	if (strcmp(argv[1], "show") == 0 || strcmp(argv[1], "list") == 0) {
-		conf->cmd = MFBPF_CMD_SHOW;
+		conf->cmd = DF_BPF_CMD_SHOW;
+		goto show_exit;
+	} else if (strcmp(argv[1], "set") == 0) {
+		conf->cmd = DF_BPF_CMD_SET;
+		goto show_exit;
+	} else if (strcmp(argv[1], "on") == 0) {
+		conf->cmd = DF_BPF_CMD_ON;
+		goto show_exit;
+	} else if (strcmp(argv[1], "off") == 0) {
+		conf->cmd = DF_BPF_CMD_OFF;
 		goto show_exit;
 	} else if (strcmp(argv[1], "help") == 0) {
-		conf->cmd = MFBPF_CMD_HELP;
+		conf->cmd = DF_BPF_CMD_HELP;
 		goto show_exit;
 	}
 #if 0
@@ -569,7 +740,7 @@ static int parse_args(int argc, char *argv[], struct mfbpf_conf *conf)
 	}
 
 	if (strcmp(argv[1], "set") == 0 && strcmp(argv[2], "delay"))
-		conf->cmd = MFBPF_CMD_SETDELAY;
+		conf->cmd = DF_BPF_CMD_SETDELAY;
 	else {
 		usage();
 		exit(1);
@@ -588,8 +759,8 @@ show_exit:
 int main(int argc, char *argv[])
 {
 	char *prog;
-	struct mfbpf_conf conf;
-	struct mfbpf_obj *obj;
+	struct df_bpf_conf conf;
+	struct df_bpf_obj *obj;
 	int err;
 
 	if ((prog = strchr(argv[0], '/')) != NULL)
@@ -600,13 +771,13 @@ int main(int argc, char *argv[])
 	if (parse_args(argc, argv, &conf) != 0)
 		exit(1);
 
-	if ((obj = mfbpf_obj_get(conf.obj)) == NULL) {
+	if ((obj = df_bpf_obj_get(conf.obj)) == NULL) {
 		fprintf(stderr, "%s: invalid object, use `-h' for help.\n",
 			prog);
 		exit(1);
 	}
 
-	if (conf.cmd == MFBPF_CMD_HELP) {
+	if (conf.cmd == DF_BPF_CMD_HELP) {
 		if (obj->help) {
 			obj->help();
 			return ETR_OK;

--- a/agent/src/ebpf/user/log.c
+++ b/agent/src/ebpf/user/log.c
@@ -97,12 +97,14 @@ void _ebpf_error(int how_to_die, char *function_name, char *file_path,
 
 	if (function_name) {
 		if (how_to_die & ERROR_WARNING) {
-			len += snprintf(msg + len, max - len, "%d-%02d-%02d %d:%d:%d \033[0;35m[eBPF] ",
+			len += snprintf(msg + len, max - len,
+					"%d-%02d-%02d %02d:%02d:%02d \033[0;35m[eBPF] ",
 					(1900 + p->tm_year), (1 + p->tm_mon), p->tm_mday,
 					p->tm_hour, p->tm_min, p->tm_sec);
 			len += snprintf(msg + len, max - len, "WARNING: func %s()", function_name);
 		} else {
-			len += snprintf(msg + len, max - len, "%d-%02d-%02d %d:%d:%d \033[0;31m[eBPF] ",
+			len += snprintf(msg + len, max - len,
+					"%d-%02d-%02d %02d:%02d:%02d \033[0;31m[eBPF] ",
 					(1900 + p->tm_year), (1 + p->tm_mon), p->tm_mday,
 					p->tm_hour, p->tm_min, p->tm_sec);
 			len += snprintf(msg + len, max - len, "ERROR: func %s()", function_name);
@@ -141,7 +143,8 @@ void _ebpf_info(char *fmt, ...)
 	p = localtime(&timep);
 	va_list va;
 
-	len += snprintf(msg + len, max - len, "%d-%02d-%02d %d:%d:%d [eBPF] INFO ",
+	len += snprintf(msg + len, max - len,
+			"%d-%02d-%02d %02d:%02d:%02d [eBPF] INFO ",
 			(1900 + p->tm_year), (1 + p->tm_mon), p->tm_mday,
 			p->tm_hour, p->tm_min, p->tm_sec);
 

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -16,15 +16,11 @@
 
 #ifndef DF_USER_SOCKET_H
 #define DF_USER_SOCKET_H
+#include "config.h"
 
 #ifndef CACHE_LINE_SIZE
 #define CACHE_LINE_SIZE 64
 #endif
-
-#define SK_TRACER_NAME  "socket-trace"
-
-// trace map回收的最大比例（指当前数量超过了整个MAP的容量的回收比例才进行回收）
-#define RECLAIM_TRACE_MAP_SCALE  0.9
 
 #define CACHE_LINE_ROUNDUP(size) \
   (CACHE_LINE_SIZE * ((size + CACHE_LINE_SIZE - 1) / CACHE_LINE_SIZE))
@@ -148,6 +144,11 @@ struct bpf_socktrace_params {
 	uint32_t kern_socket_map_used;
 	uint32_t kern_trace_map_max;
 	uint32_t kern_trace_map_used;
+	bool datadump_enable;
+	int datadump_pid;
+	uint8_t datadump_proto;
+	char datadump_file_path[DATADUMP_FILE_PATH_SIZE];
+	char datadump_comm[16];
 	struct bpf_offset_param_array offset_array;
 };
 
@@ -159,6 +160,40 @@ struct extra_event {
 	uint32_t type;
 	void (*h)(void *);
 };
+
+static inline char *get_proto_name(uint16_t proto_id)
+{
+	switch (proto_id) {
+	case PROTO_HTTP1:
+		return "HTTP1";
+	case PROTO_HTTP2:
+		return "HTTP2";
+	case PROTO_TLS_HTTP1:
+		return "TLS_HTTP1";
+	case PROTO_TLS_HTTP2:
+		return "TLS_HTTP2";
+	case PROTO_MYSQL:
+		return "MySQL";
+	case PROTO_DNS:
+		return "DNS";
+	case PROTO_REDIS:
+		return "Redis";
+	case PROTO_KAFKA:
+		return "Kafka";
+	case PROTO_MQTT:
+		return "MQTT";
+	case PROTO_DUBBO:
+		return "Dubbo";
+	case PROTO_SOFARPC:
+		return "SofaRPC";
+	case PROTO_POSTGRESQL:
+		return "PgSQL";
+	default:
+		return "Unknown";
+	}
+
+	return "Unknown";
+}
 
 int set_data_limit_max(int limit_size);
 struct socket_trace_stats socket_tracer_stats(void);

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -184,20 +184,23 @@ enum {
 	SOCKOPT_SET_TRACER_DEL,
 	SOCKOPT_SET_TRACER_SET,
 	SOCKOPT_SET_TRACER_FLUSH,
-
 	/* get */
 	SOCKOPT_GET_TRACER_SHOW,
-};
 
-enum {
 	/* set */
 	SOCKOPT_SET_SOCKTRACE_ADD = 500,
 	SOCKOPT_SET_SOCKTRACE_DEL,
 	SOCKOPT_SET_SOCKTRACE_SET,
 	SOCKOPT_SET_SOCKTRACE_FLUSH,
-
 	/* get */
 	SOCKOPT_GET_SOCKTRACE_SHOW,
+
+	/* set */
+	SOCKOPT_SET_DATADUMP_ADD = 600,
+	SOCKOPT_SET_DATADUMP_ON,
+	SOCKOPT_SET_DATADUMP_OFF,
+	/* get */
+	SOCKOPT_GET_DATADUMP_SHOW
 };
 
 struct mem_block_head {
@@ -303,6 +306,7 @@ struct bpf_tracer {
 	int dispatch_workers_nr;		// 分发线程数量
 	struct queue queues[MAX_CPU_NR];	// 分发队列，每个分发线程都有其对应的队列。
 	void *process_fn;			// 回调应用传递过来的接口, 进行数据处理
+	void (*datadump) (void *data);		// eBPF data dump handle
 
 	/*
 	 * perf ring-buffer from kernel to user.
@@ -445,6 +449,8 @@ prefetch_and_process_datas(struct bpf_tracer *t, int nb_rx, void **datas_burst)
 		if (block_head->fn != NULL) {
 			block_head->fn(sd);
 		} else {
+			if (t->datadump)
+				t->datadump((void *)sd);
 			callback(sd);
 		}
 


### PR DESCRIPTION
The ebpf data can be dump to a file by the command line tool(deepflow-ebpfctl) configuration.

```
Usage:
    deepflow-ebpfctl datadump {on|off} [OPTIONS]
    deepflow-ebpfctl datadump set pid PID comm COMM proto PROTO_NUM
PROTO_NUM:
    0:   PROTO_ALL
    1:   PROTO_ORTHER
    20:  PROTO_HTTP1
    21:  PROTO_HTTP2
    22:  PROTO_TLS_HTTP1
    23:  PROTO_TLS_HTTP2
    40:  PROTO_DUBBO
    43:  PROTO_SOFARPC
    60:  PROTO_MYSQL
    61:  PROTO_POSTGRESQL
    80:  PROTO_REDIS
    100: PROTO_KAFKA
    101: PROTO_MQTT
    120: PROTO_DNS
PID:
    0:   all process/thread
COMM:
    '':  The process name or thread name is not restricted.
Options:
    '-O, --only-stdout':  dump to stdout only.
    '-t, --timeout':      set datadump timout. Unit: second
For example:
    deepflow-ebpfctl datadump set pid 4567 comm curl proto 0
    deepflow-ebpfctl datadump set pid 4567 comm '' proto 20
    deepflow-ebpfctl datadump on --timeout 60
    deepflow-ebpfctl datadump on --only-stdout --timeout 60
    deepflow-ebpfctl datadump off

View Settings:

deepflow-ebpfctl socktrace show

Linux Version: Linux 4.19.17

datadump_enable:        true
datadump_pid:   0
datadump_proto: 0
datadump_comm:
datadump_file_path:     /var/run/datadump-2023_01_09_10_52_11_156.log
```

### This PR is for:


- Agent



#### Affected branches
- main
- v6.1

#### Checklist
- [ ] Added unit test.

