### PR TITLE
[Agent] Fix nat source of TOA flow is 0. #1481

### DIFF
--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -993,7 +993,9 @@ impl FlowMap {
 
         let nat_source = meta_packet.lookup_key.get_nat_source();
         meta_packet.tap_port.set_nat_source(nat_source);
-        flow.flow_key.tap_port.set_nat_source(nat_source);
+        if nat_source > flow.flow_key.tap_port.get_nat_source() {
+            flow.flow_key.tap_port.set_nat_source(nat_source);
+        }
 
         // The ebpf data has no l3 and l4 information, so it can be returned directly
         if flow.signal_source == SignalSource::EBPF {


### PR DESCRIPTION
### This PR is for:

- Agent

#1481

### Fix nat source of TOA flow is 0
#### Steps to reproduce the bug
#### Changes to fix the bug
- Ignore packets with low nat source priority
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ====
### <Feature description (with issue link if any)>
#### Checklist
- [ ] Added unit test.
#### Backport to branches
- <branch name here>
     ==== Remove this line WHEN AND ONLY WHEN you're adding a new feature, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->
