### PR TITLE
[Agent] fix guard cgroup check

### DIFF
--- a/agent/crates/public/src/consts.rs
+++ b/agent/crates/public/src/consts.rs
@@ -33,6 +33,10 @@ pub const DEFAULT_CPU_CFS_PERIOD_US: u32 = 100000; // cfs_period_us默认值
 
 pub const DEFAULT_LOG_RETENTION: u32 = 365;
 pub const DEFAULT_LOG_FILE_SIZE_LIMIT: u32 = 10000; // 单位：M
+pub const CGROUP_PROCS_PATH: &'static str = "cpu/deepflow-agent/cgroup.procs";
+pub const CGROUP_TASKS_PATH: &'static str = "cpu/deepflow-agent/tasks";
+pub const CGROUP_V2_PROCS_PATH: &'static str = "deepflow-agent/cgroup.procs";
+pub const CGROUP_V2_THREADS_PATH: &'static str = "deepflow-agent/cgroup.threads";
 
 #[cfg(target_os = "linux")]
 mod platform_consts {
@@ -41,10 +45,6 @@ mod platform_consts {
     pub const COREFILE_FORMAT: &'static str = "core";
     pub const DEFAULT_COREFILE_PATH: &'static str = "/tmp";
     pub const DEFAULT_LIBVIRT_XML_PATH: &'static str = "/etc/libvirt/qemu";
-    pub const CGROUP_PROCS_PATH: &'static str = "/sys/fs/cgroup/cpu/deepflow-agent/cgroup.procs";
-    pub const CGROUP_TASKS_PATH: &'static str = "/sys/fs/cgroup/cpu/deepflow-agent/tasks";
-    pub const CGROUP_V2_PROCS_PATH: &'static str = "/sys/fs/cgroup/deepflow-agent/cgroup.procs";
-    pub const CGROUP_V2_THREADS_PATH: &'static str = "/sys/fs/cgroup/deepflow-agent/cgroup.threads";
 }
 
 #[cfg(target_os = "windows")]

--- a/agent/src/trident.rs
+++ b/agent/src/trident.rs
@@ -80,6 +80,7 @@ use crate::{
     rpc::{Session, Synchronizer, DEFAULT_TIMEOUT},
     sender::{get_sender_id, npb_sender::NpbArpTable, uniform_sender::UniformSenderThread},
     utils::{
+        cgroups::{is_kernel_available_for_cgroup, Cgroups},
         environment::{
             check, controller_ip_check, free_memory_check, free_space_checker, get_ctrl_ip_and_mac,
             kernel_check, running_in_container, running_in_only_watch_k8s_mode,
@@ -96,10 +97,7 @@ use crate::{
 use crate::{
     ebpf_dispatcher::EbpfCollector,
     platform::{ApiWatcher, SocketSynchronizer},
-    utils::{
-        cgroups::Cgroups,
-        environment::{core_file_check, is_tt_pod},
-    },
+    utils::environment::{core_file_check, is_tt_pod},
 };
 
 #[cfg(target_os = "linux")]
@@ -378,14 +376,22 @@ impl Trident {
         );
         synchronizer.start();
 
-        #[cfg(target_os = "linux")]
+        let mut cgroup_mount_path = "".to_string();
+        let mut is_cgroup_v2 = false;
         let mut cgroups_controller = None;
-        #[cfg(target_os = "linux")]
-        if config_handler.candidate_config.tap_mode != TapMode::Analyzer && !running_in_container()
-        {
+        if config_handler.candidate_config.tap_mode == TapMode::Analyzer {
+            warn!("don't initialize cgroup controller, because agent in Analyzer mode.");
+        } else if running_in_container() {
+            warn!("don't initialize cgroup controller, because agent is running in container");
+        } else if !is_kernel_available_for_cgroup() {
+            // fixme: Linux after kernel version 2.6.24 can use cgroup
+            warn!("don't initialize cgroup controller, because kernel version < 3 or agent is in Windows");
+        } else {
             match Cgroups::new(process::id() as u64, config_handler.environment()) {
                 Ok(cg_controller) => {
                     cg_controller.start();
+                    cgroup_mount_path = cg_controller.get_mount_path();
+                    is_cgroup_v2 = cg_controller.is_v2();
                     cgroups_controller = Some(cg_controller);
                 }
                 Err(e) => {
@@ -396,7 +402,7 @@ impl Trident {
                     thread::sleep(Duration::from_secs(1));
                     process::exit(1);
                 }
-            };
+            }
         }
 
         let log_dir = Path::new(config_handler.static_config.log_file.as_str());
@@ -407,6 +413,8 @@ impl Trident {
             config_handler.candidate_config.yaml_config.guard_interval,
             config_handler.candidate_config.tap_mode,
             exception_handler.clone(),
+            cgroup_mount_path,
+            is_cgroup_v2,
         );
         guard.start();
 
@@ -462,12 +470,10 @@ impl Trident {
                         platform_synchronizer.stop();
 
                         #[cfg(target_os = "linux")]
-                        {
-                            libvirt_xml_extractor.stop();
-                            if let Some(cg_controller) = cgroups_controller {
-                                if let Err(e) = cg_controller.stop() {
-                                    warn!("stop cgroup controller failed, {:?}", e);
-                                }
+                        libvirt_xml_extractor.stop();
+                        if let Some(cg_controller) = cgroups_controller {
+                            if let Err(e) = cg_controller.stop() {
+                                warn!("stop cgroup controller failed, {:?}", e);
                             }
                         }
                     }
@@ -1987,8 +1993,11 @@ impl AgentComponents {
             packet_sequence_parser.start();
         }
 
+        // When tap_mode is Analyzer mode and agent is not running in container and agent
+        // in the environment where cgroup is not supported, we need to check free memory
         if self.tap_mode != TapMode::Analyzer
-            && self.config.platform.kubernetes_cluster_id.is_empty()
+            && !running_in_container()
+            && !is_kernel_available_for_cgroup()
         {
             match free_memory_check(self.max_memory, &self.exception_handler) {
                 Ok(()) => {

--- a/agent/src/utils/cgroups/mod.rs
+++ b/agent/src/utils/cgroups/mod.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use thiserror::Error;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use self::windows::*;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("cgroup is not supported: {0}")]
+    CgroupNotSupported(String),
+    #[error("set cpu controller failed: {0}")]
+    CpuControllerSetFailed(String),
+    #[error("set mem controller failed: {0}")]
+    MemControllerSetFailed(String),
+    #[error("apply resources failed: {0}")]
+    ApplyResourcesFailed(String),
+    #[error("delete cgroup failed: {0}")]
+    DeleteCgroupFailed(String),
+}

--- a/agent/src/utils/cgroups/windows.rs
+++ b/agent/src/utils/cgroups/windows.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+use std::{process, thread};
+
+use super::Error;
+use crate::config::handler::EnvironmentAccess;
+
+use log::{info, warn};
+
+pub struct Cgroups {}
+
+impl Cgroups {
+    pub fn new(_pid: u64, _config: EnvironmentAccess) -> Result<Self, Error> {
+        Err(Error::CgroupNotSupported(
+            "Windows agent's cgroup is not supported".to_string(),
+        ))
+    }
+    pub fn start(&self) {}
+    pub fn get_mount_path(&self) -> String {
+        String::default()
+    }
+    pub fn is_v2(&self) -> bool {
+        false
+    }
+    pub fn stop(&self) -> Result<(), Error> {
+        Err(Error::CgroupNotSupported(
+            "Windows agent's cgroup is not supported".to_string(),
+        ))
+    }
+}
+
+pub fn is_kernel_available_for_cgroup() -> bool {
+    false
+}

--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -56,7 +56,9 @@ use crate::error::{Error, Result};
 use crate::exception::ExceptionHandler;
 use public::proto::{common::TridentType, trident::Exception};
 
-use super::process::{get_memory_rss, get_process_num_by_name};
+#[cfg(target_os = "windows")]
+use super::process::get_memory_rss;
+use super::process::get_process_num_by_name;
 #[cfg(target_os = "linux")]
 use public::utils::net::get_link_enabled_features;
 use public::utils::net::{
@@ -143,6 +145,12 @@ pub fn tap_interface_check(tap_interfaces: &[String]) {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub fn free_memory_check(_required: u64, _exception_handler: &ExceptionHandler) -> Result<()> {
+    return Ok(()); // fixme: The way to obtain free memory is different in earlier versions of Linux, which requires adaptation
+}
+
+#[cfg(target_os = "windows")]
 pub fn free_memory_check(required: u64, exception_handler: &ExceptionHandler) -> Result<()> {
     get_memory_rss()
         .map_err(|e| Error::Environment(e.to_string()))

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#[cfg(target_os = "linux")]
 pub(crate) mod cgroups;
 pub(crate) mod command;
 pub(crate) mod environment;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes guard cgroup check
#### Steps to reproduce the bug
- Modify the default mount directory of cgroup. The cgroup check in guard will cause the agent to restart
#### Changes to fix the bug
- Get the mount directory of cgroup and check the procs file and tasks file under the path instead of checking the fixed file path
- When the kernel version is too low, do not set cgroup and only print the warning log
- Optimize free memory check
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
     