### PR TITLE
[Server] add filter to remote segements

### DIFF
--- a/server/controller/trisolaris/metadata/metadata.go
+++ b/server/controller/trisolaris/metadata/metadata.go
@@ -17,12 +17,12 @@
 package metadata
 
 import (
-	"gorm.io/gorm"
 	"sync/atomic"
 	"time"
 
 	mapset "github.com/deckarep/golang-set"
 	"github.com/op/go-logging"
+	"gorm.io/gorm"
 
 	"github.com/deepflowys/deepflow/message/trident"
 	"github.com/deepflowys/deepflow/server/controller/trisolaris/config"


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Server

### add filter to remote segements
#### Changes to fix the bug
- Filter the remote segment whose mac is empty or default.
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
 