### PR TITLE
[AGENT] Reduce memory consumption for Option fields

### DIFF
--- a/agent/benches/flow_generator/flow_map.rs
+++ b/agent/benches/flow_generator/flow_map.rs
@@ -28,7 +28,7 @@ use public::proto::common::TridentType;
 pub(super) fn bench(c: &mut Criterion) {
     c.bench_function("flow_map_syn_flood", |b| {
         b.iter_custom(|iters| {
-            let (mut map, _) = new_flow_map_and_receiver(TridentType::TtProcess);
+            let (mut map, _) = new_flow_map_and_receiver(TridentType::TtProcess, None);
             let packets = (0..iters)
                 .into_iter()
                 .map(|i| {
@@ -48,7 +48,7 @@ pub(super) fn bench(c: &mut Criterion) {
 
     c.bench_function("flow_map_with_ten_packets_flow_flood", |b| {
         b.iter_custom(|iters| {
-            let (mut map, _) = new_flow_map_and_receiver(TridentType::TtProcess);
+            let (mut map, _) = new_flow_map_and_receiver(TridentType::TtProcess, None);
             let iters = (iters + 9) / 10 * 10;
 
             let mut packets = vec![];

--- a/agent/src/collector/flow_aggr.rs
+++ b/agent/src/collector/flow_aggr.rs
@@ -29,7 +29,6 @@ use npb_pcap_policy::NpbTunnelType;
 use rand::prelude::{Rng, SeedableRng, SmallRng};
 
 use super::consts::*;
-use super::round_to_minute;
 
 use crate::collector::acc_flow::U16Set;
 use crate::common::{
@@ -233,12 +232,12 @@ impl FlowAggr {
         f.flow.acl_gids = Vec::from(acl_gids.list());
 
         if !f.flow.is_new_flow {
-            f.flow.start_time = round_to_minute(f.flow.flow_stat_time);
+            f.flow.start_time = f.flow.flow_stat_time.round_to_minute();
         }
 
         if f.flow.close_type == CloseType::ForcedReport {
             f.flow.end_time =
-                round_to_minute(f.flow.flow_stat_time + Duration::from_secs(SECONDS_IN_MINUTE));
+                (f.flow.flow_stat_time + Duration::from_secs(SECONDS_IN_MINUTE)).round_to_minute();
         }
         self.metrics.out.fetch_add(1, Ordering::Relaxed);
         if !self.output.send(f) {

--- a/agent/src/collector/quadruple_generator.rs
+++ b/agent/src/collector/quadruple_generator.rs
@@ -1147,7 +1147,7 @@ impl QuadrupleGenerator {
                         if self.collector_enabled.load(Ordering::Relaxed) {
                             self.handle(
                                 Some(Arc::clone(&tagged_flow)),
-                                tagged_flow.flow.flow_stat_time,
+                                tagged_flow.flow.flow_stat_time.into(),
                             );
                         }
 

--- a/agent/src/common/l7_protocol_log.rs
+++ b/agent/src/common/l7_protocol_log.rs
@@ -219,30 +219,91 @@ macro_rules! perf_impl {
     };
 }
 
-macro_rules! all_protocol {
-    ($( $l7_proto:ident , $parser:ident , $log:ident::$new_func:ident);+$(;)?) => {
-        #[enum_dispatch]
-        pub enum L7ProtocolParser {
-            HttpParser(HttpLog),
+macro_rules! impl_protocol_parser {
+    (pub enum $name:ident { $($proto:ident($log_type:ty)),* $(,)? }) => {
+        pub enum $name {
+            Http(Box<HttpLog>),
+            $($proto($log_type)),*
+        }
 
-            $(
-                $parser($log),
-            )+
+        impl L7ProtocolParserInterface for $name {
+            fn check_payload(&mut self, payload: &[u8], param: &ParseParam) -> bool {
+                match self {
+                    Self::Http(p) => p.check_payload(payload, param),
+                    $(Self::$proto(p) => p.check_payload(payload, param)),*
+                }
+            }
+
+            fn parse_payload(&mut self, payload: &[u8], param: &ParseParam) -> Result<Vec<L7ProtocolInfo>> {
+                match self {
+                    Self::Http(p) => p.parse_payload(payload, param),
+                    $(Self::$proto(p) => p.parse_payload(payload, param)),*
+                }
+            }
+
+            fn protocol(&self) -> L7Protocol {
+                match self {
+                    Self::Http(p) => p.protocol(),
+                    $(Self::$proto(p) => p.protocol()),*
+                }
+            }
+
+            fn protobuf_rpc_protocol(&self) -> Option<ProtobufRpcProtocol> {
+                match self {
+                    Self::Http(p) => p.protobuf_rpc_protocol(),
+                    $(Self::$proto(p) => p.protobuf_rpc_protocol()),*
+                }
+            }
+
+            fn l7_protocl_enum(&self) -> L7ProtocolEnum {
+                match self {
+                    Self::Http(p) => p.l7_protocl_enum(),
+                    $(Self::$proto(p) => p.l7_protocl_enum()),*
+                }
+            }
+
+            fn parsable_on_tcp(&self) -> bool {
+                match self {
+                    Self::Http(p) => p.parsable_on_tcp(),
+                    $(Self::$proto(p) => p.parsable_on_tcp()),*
+                }
+            }
+
+            fn parsable_on_udp(&self) -> bool {
+                match self {
+                    Self::Http(p) => p.parsable_on_udp(),
+                    $(Self::$proto(p) => p.parsable_on_udp()),*
+                }
+            }
+
+            fn parse_default(&self) -> bool {
+                match self {
+                    Self::Http(p) => p.parse_default(),
+                    $(Self::$proto(p) => p.parse_default()),*
+                }
+            }
+
+            fn reset(&mut self) {
+                match self {
+                    Self::Http(p) => p.reset(),
+                    $(Self::$proto(p) => p.reset()),*
+                }
+            }
         }
 
         impl L7ProtocolParser {
             pub fn as_str(&self) -> &'static str {
                 match self {
-                    L7ProtocolParser::HttpParser(http) => {
-                        match http.protocol() {
+                    Self::Http(p) => {
+                        match p.protocol() {
                             L7Protocol::Http1 => return "HTTP",
                             L7Protocol::Http2 => return "HTTP2",
                             _ => unreachable!()
                         }
                     },
                     $(
-                        L7ProtocolParser::$parser(_) => stringify!($l7_proto),
-                    )+
+                        Self::$proto(_) => stringify!($proto),
+                    )*
                 }
             }
         }
@@ -252,11 +313,11 @@ macro_rules! all_protocol {
 
             fn try_from(value: &str) -> Result<Self, Self::Error> {
                 match value {
-                    "HTTP" => Ok(L7ProtocolParser::HttpParser(HttpLog::new_v1())),
-                    "HTTP2" => Ok(L7ProtocolParser::HttpParser(HttpLog::new_v2(false))),
+                    "HTTP" => Ok(Self::Http(Box::new(HttpLog::new_v1()))),
+                    "HTTP2" => Ok(Self::Http(Box::new(HttpLog::new_v2(false)))),
                     $(
-                        stringify!($l7_proto) => Ok(L7ProtocolParser::$parser($log::$new_func())),
-                    )+
+                        stringify!($proto) => Ok(Self::$proto(Default::default())),
+                    )*
                     _ => Err(String::from(format!("unknown protocol {}",value))),
                 }
             }
@@ -265,31 +326,29 @@ macro_rules! all_protocol {
         pub fn get_parser(p: L7ProtocolEnum) -> Option<L7ProtocolParser> {
             match p {
                 L7ProtocolEnum::L7Protocol(p) => match p {
-                    L7Protocol::Http1 | L7Protocol::Http1TLS => Some(L7ProtocolParser::HttpParser(HttpLog::new_v1())),
-                    L7Protocol::Http2 | L7Protocol::Http2TLS => Some(L7ProtocolParser::HttpParser(HttpLog::new_v2(false))),
-                    L7Protocol::Grpc => Some(L7ProtocolParser::HttpParser(HttpLog::new_v2(true))),
+                    L7Protocol::Http1 | L7Protocol::Http1TLS => Some(L7ProtocolParser::Http(Box::new(HttpLog::new_v1()))),
+                    L7Protocol::Http2 | L7Protocol::Http2TLS => Some(L7ProtocolParser::Http(Box::new(HttpLog::new_v2(false)))),
+                    L7Protocol::Grpc => Some(L7ProtocolParser::Http(Box::new(HttpLog::new_v2(true)))),
 
                     $(
-                        L7Protocol::$l7_proto => Some(L7ProtocolParser::$parser($log::$new_func())),
+                        L7Protocol::$proto => Some(L7ProtocolParser::$proto(Default::default())),
                     )+
                     _ => None,
                 },
-
                 L7ProtocolEnum::ProtobufRpc(p) => Some(get_protobuf_rpc_parser(p)),
             }
         }
 
         pub fn get_all_protocol() -> Vec<L7ProtocolParser> {
             Vec::from([
-                L7ProtocolParser::HttpParser(HttpLog::new_v1()),
-                L7ProtocolParser::HttpParser(HttpLog::new_v2(false)),
-
+                L7ProtocolParser::Http(Box::new(HttpLog::new_v1())),
+                L7ProtocolParser::Http(Box::new(HttpLog::new_v2(false))),
                 $(
-                    L7ProtocolParser::$parser($log::$new_func()),
+                    L7ProtocolParser::$proto(Default::default()),
                 )+
             ])
         }
-    };
+    }
 }
 
 /*
@@ -322,33 +381,35 @@ pub fn get_all_protocol() -> Vec<L7ProtocolParser> {
         L7ProtocolParser::MysqlParser(MysqlLog::default()),
         ...
     ])
-
 }
-
 */
 
 // 内部实现的协议
 // log的具体结构和实现在 src/flow_generator/protocol_logs/** 下
+// 注意枚举名大小写，因为会用于字符串解析
+// 大结构体（128B以上）注意加Box，减少内存使用
 // =========================================================
 // the inner implement protocol source code in src/flow_generator/protocol_logs/**
+// enum name will be used to parse strings so case matters
+// large structs (>128B) should be boxed to reduce memory consumption
+//
+impl_protocol_parser! {
+    pub enum L7ProtocolParser {
+        // http have two version but one parser, can not place in macro param.
+        DNS(DnsLog),
+        ProtobufRPC(Box<ProtobufRpcWrapLog>),
+        SofaRPC(Box<SofaRpcLog>),
+        MySQL(MysqlLog),
+        Kafka(KafkaLog),
+        Redis(Box<RedisLog>),
+        PostgreSQL(Box<PostgresqlLog>),
+        Dubbo(Box<DubboLog>),
+        MQTT(MqttLog),
+        // add protocol below
+    }
+}
 
-// l7Protocol , enumName , ParserImplement::newFuncName
-// l7Protocol will act as the protocol string
-all_protocol!(
-    // http have two version but one parser, can not place in macro param.
-    DNS,DnsParser,DnsLog::default;
-    ProtobufRPC,ProtobufRpcParser,ProtobufRpcWrapLog::new;
-    SofaRPC,SofaRpcParser,SofaRpcLog::new;
-    MySQL,MysqlParser,MysqlLog::default;
-    Kafka,KafkaParser,KafkaLog::new;
-    Redis,RedisParser,RedisLog::default;
-    PostgreSQL,PostgresParser,PostgresqlLog::new;
-    Dubbo,DubboParser,DubboLog::default;
-    MQTT,MqttParser,MqttLog::default;
-    // add protocol below
-);
-
-#[enum_dispatch(L7ProtocolParser)]
+#[enum_dispatch]
 pub trait L7ProtocolParserInterface {
     fn check_payload(&mut self, payload: &[u8], param: &ParseParam) -> bool;
     // 协议解析

--- a/agent/src/common/mod.rs
+++ b/agent/src/common/mod.rs
@@ -29,7 +29,7 @@ pub mod meta_packet;
 pub mod platform_data;
 pub mod policy;
 pub mod port_range;
-mod tag;
+pub(crate) mod tag;
 pub mod tagged_flow;
 pub mod tap_port;
 pub mod tap_types;

--- a/agent/src/common/mod.rs
+++ b/agent/src/common/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod tag;
 pub mod tagged_flow;
 pub mod tap_port;
 pub mod tap_types;
+pub mod timestamp;
 
 pub use consts::*;
 pub use feature::FeatureFlags;
@@ -42,6 +43,7 @@ pub use public::enums;
 pub use tagged_flow::TaggedFlow;
 pub use tap_port::TapPort;
 pub use tap_types::TapTyper;
+pub use timestamp::{timestamp_to_micros, Timestamp};
 
 use std::{
     fmt,

--- a/agent/src/common/tagged_flow.rs
+++ b/agent/src/common/tagged_flow.rs
@@ -113,13 +113,13 @@ impl Sendable for BoxedTaggedFlow {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use prost::Message;
 
     use super::*;
 
-    use crate::common::{decapsulate::TunnelType, flow::FlowPerfStats, flow::L4Protocol};
+    use crate::common::{
+        decapsulate::TunnelType, flow::FlowPerfStats, flow::L4Protocol, Timestamp,
+    };
 
     // test run: cargo test --package trident --lib -- common::tagged_flow::tests::sequential_merge --exact --nocapture
     #[test]
@@ -134,7 +134,7 @@ mod tests {
         f1.flow.flow_metrics_peers[0].byte_count = 20;
         f.flow.flow_metrics_peers[1].l3_byte_count = 30;
         f1.flow.flow_metrics_peers[1].l3_byte_count = 40;
-        f1.flow.flow_perf_stats = Some(FlowPerfStats::default());
+        f1.flow.flow_perf_stats = Some(Default::default());
         f1.flow.flow_perf_stats.as_mut().unwrap().tcp.rtt_client_max = 100;
 
         f.sequential_merge(&f1);
@@ -167,11 +167,11 @@ mod tests {
         tflow.flow.flow_metrics_peers[1].byte_count = 6;
         tflow.flow.tunnel.tunnel_type = TunnelType::Vxlan;
         tflow.flow.flow_id = 8;
-        tflow.flow.start_time = Duration::from_nanos(100_000_000_001);
+        tflow.flow.start_time = Timestamp::from_nanos(100_000_000_001);
         let mut flow_perf_stats = FlowPerfStats::default();
         flow_perf_stats.l4_protocol = L4Protocol::Tcp;
         flow_perf_stats.tcp.rtt = 10;
-        tflow.flow.flow_perf_stats = Some(flow_perf_stats);
+        tflow.flow.flow_perf_stats = Some(Box::new(flow_perf_stats));
         tflow.flow.is_active_service = true;
 
         let mut buf: Vec<u8> = vec![];

--- a/agent/src/common/timestamp.rs
+++ b/agent/src/common/timestamp.rs
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// This module provides a 8B timestamp struct for memory-sensitive structs
+// std::time::Duration is 16B
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::ops::{Add, AddAssign, Sub};
+use std::time::Duration;
+
+use serde::Serializer;
+
+#[derive(Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Timestamp(u64);
+
+impl From<Duration> for Timestamp {
+    fn from(d: Duration) -> Self {
+        Self(d.as_nanos() as u64)
+    }
+}
+
+impl From<Timestamp> for Duration {
+    fn from(t: Timestamp) -> Self {
+        Self::from_nanos(t.as_nanos())
+    }
+}
+
+impl fmt::Debug for Timestamp {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Duration::from(*self).fmt(f)
+    }
+}
+
+impl Timestamp {
+    const NANOS_IN_MINUTE: u64 = Duration::from_secs(60).as_nanos() as u64;
+    const NANOS_IN_SECOND: u64 = Duration::from_secs(1).as_nanos() as u64;
+    const NANOS_IN_MICROS: u64 = Duration::from_micros(1).as_nanos() as u64;
+
+    pub const ZERO: Self = Self(0);
+
+    pub const fn from_nanos(nanos: u64) -> Self {
+        Self(nanos)
+    }
+
+    pub const fn from_micros(micros: u64) -> Self {
+        Self(micros * Self::NANOS_IN_MICROS)
+    }
+
+    pub const fn from_secs(secs: u64) -> Self {
+        Self(secs * Self::NANOS_IN_SECOND)
+    }
+
+    pub const fn as_secs(&self) -> u64 {
+        self.0 / Self::NANOS_IN_SECOND
+    }
+
+    pub const fn as_micros(&self) -> u64 {
+        self.0 / Self::NANOS_IN_MICROS
+    }
+
+    pub const fn as_nanos(&self) -> u64 {
+        self.0
+    }
+
+    pub const fn is_zero(&self) -> bool {
+        self.0 == 0
+    }
+
+    pub const fn round_to_minute(&self) -> Self {
+        Self(self.0 / Self::NANOS_IN_MINUTE * Self::NANOS_IN_MINUTE)
+    }
+}
+
+impl PartialEq<Duration> for Timestamp {
+    fn eq(&self, other: &Duration) -> bool {
+        self.0.eq(&(other.as_nanos() as u64))
+    }
+}
+
+impl PartialEq<Timestamp> for Duration {
+    fn eq(&self, other: &Timestamp) -> bool {
+        other.eq(self)
+    }
+}
+
+impl PartialOrd<Duration> for Timestamp {
+    fn partial_cmp(&self, other: &Duration) -> Option<Ordering> {
+        Some(self.0.cmp(&(other.as_nanos() as u64)))
+    }
+}
+
+impl PartialOrd<Timestamp> for Duration {
+    fn partial_cmp(&self, other: &Timestamp) -> Option<Ordering> {
+        other.partial_cmp(self).map(Ordering::reverse)
+    }
+}
+
+impl Add for Timestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
+    }
+}
+
+impl Add<Duration> for Timestamp {
+    type Output = Self;
+
+    fn add(self, rhs: Duration) -> Self::Output {
+        self + Self::from(rhs)
+    }
+}
+
+impl AddAssign for Timestamp {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0
+    }
+}
+
+impl Sub<Timestamp> for Duration {
+    type Output = Self;
+
+    fn sub(self, rhs: Timestamp) -> Self::Output {
+        self - Self::from(rhs)
+    }
+}
+
+impl Sub<Duration> for Timestamp {
+    type Output = Self;
+
+    fn sub(self, rhs: Duration) -> Self::Output {
+        if self.0 < rhs.as_nanos() as u64 {
+            panic!("overflow when subtracting timestamp")
+        }
+        Self(self.0 - rhs.as_nanos() as u64)
+    }
+}
+
+pub fn timestamp_to_micros<S>(d: &Timestamp, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    serializer.serialize_u64(d.as_micros())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn conversion() {
+        let d = Duration::from_secs(123);
+        assert_eq!(d, Duration::from(Timestamp::from(d)));
+    }
+
+    #[test]
+    fn comparison() {
+        assert_eq!(
+            Timestamp::from_secs(123),
+            Timestamp::from(Duration::from_secs(123))
+        );
+        assert_eq!(Timestamp::from_nanos(123), Duration::from_nanos(123));
+        assert_eq!(Timestamp::from_micros(123), Duration::from_micros(123));
+        assert_eq!(Timestamp::from_secs(123), Duration::from_secs(123));
+        assert_eq!(
+            Timestamp::from_secs(123).as_nanos(),
+            Duration::from_secs(123).as_nanos() as u64
+        );
+        assert_eq!(
+            Timestamp::from_secs(123).as_micros(),
+            Duration::from_secs(123).as_micros() as u64
+        );
+        assert_eq!(
+            Timestamp::from_secs(123).as_secs(),
+            Duration::from_secs(123).as_secs()
+        );
+
+        assert!(Timestamp::from_nanos(123) < Timestamp::from_secs(123));
+        assert!(Timestamp::from_micros(123) < Timestamp::from_secs(123));
+        assert!(Timestamp::from_secs(124) > Timestamp::from_secs(123));
+
+        assert!(Duration::new(1571105646, 245884000) > Timestamp::ZERO);
+        assert!(Duration::from_secs(124) > Timestamp::from_secs(123));
+        assert!(Timestamp::from_micros(123) < Duration::from_secs(123));
+    }
+
+    #[test]
+    fn arithmetics() {
+        assert_eq!(
+            Timestamp::from_micros(123) + Timestamp::from_micros(456),
+            Duration::from_micros(579)
+        );
+        assert_eq!(
+            Timestamp::from_nanos(123) + Duration::from_nanos(456),
+            Duration::from_nanos(579)
+        );
+        assert_eq!(
+            Duration::from_secs(987) - Timestamp::from_secs(654),
+            Duration::from_secs(333)
+        );
+        assert_eq!(
+            Timestamp::from_micros(987) - Duration::from_micros(654),
+            Duration::from_micros(333)
+        );
+    }
+}

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -64,6 +64,7 @@ use crate::{
         meta_packet::{MetaPacket, MetaPacketTcpHeader},
         tagged_flow::TaggedFlow,
         tap_port::TapPort,
+        Timestamp,
     },
     config::{
         handler::{L7LogDynamicConfig, LogParserAccess, LogParserConfig},
@@ -867,8 +868,8 @@ impl FlowMap {
                 TunnelField::default()
             },
             flow_id: self.generate_flow_id(lookup_key.timestamp, self.id),
-            start_time: lookup_key.timestamp,
-            flow_stat_time: Duration::from_nanos(
+            start_time: lookup_key.timestamp.into(),
+            flow_stat_time: Timestamp::from_nanos(
                 (lookup_key.timestamp.as_nanos() / TIME_UNIT.as_nanos() * TIME_UNIT.as_nanos())
                     as u64,
             ),
@@ -885,8 +886,8 @@ impl FlowMap {
                     byte_count: meta_packet.packet_len as u64,
                     l3_byte_count: meta_packet.l3_payload_len() as u64,
                     l4_byte_count: meta_packet.l4_payload_len() as u64,
-                    first: lookup_key.timestamp,
-                    last: lookup_key.timestamp,
+                    first: lookup_key.timestamp.into(),
+                    last: lookup_key.timestamp.into(),
                     tcp_flags: meta_packet.tcp_data.flags,
                     ..Default::default()
                 },
@@ -977,14 +978,14 @@ impl FlowMap {
         let flow = &mut node.tagged_flow.flow;
         if pkt_timestamp > node.recent_time {
             node.recent_time = pkt_timestamp;
-            flow.duration = node.recent_time - node.min_arrived_time
+            flow.duration = (node.recent_time - node.min_arrived_time).into();
             // Duration仅使用包的时间计算，不包括超时时间
         }
 
         if !node.packet_in_tick {
             // FlowStatTime取整至统计时间的开始，只需要赋值一次，且使用包的时间戳
             node.packet_in_tick = true;
-            flow.flow_stat_time = Duration::from_nanos(
+            flow.flow_stat_time = Timestamp::from_nanos(
                 (pkt_timestamp.as_nanos() / STATISTICAL_INTERVAL.as_nanos()
                     * STATISTICAL_INTERVAL.as_nanos()) as u64,
             );
@@ -1088,9 +1089,9 @@ impl FlowMap {
         flow_metrics_peer.l3_byte_count += meta_packet.l3_payload_len() as u64;
         flow_metrics_peer.l4_byte_count += meta_packet.l4_payload_len() as u64;
         flow_metrics_peer.total_byte_count += meta_packet.packet_len as u64;
-        flow_metrics_peer.last = pkt_timestamp;
+        flow_metrics_peer.last = pkt_timestamp.into();
         if flow_metrics_peer.first.is_zero() {
-            flow_metrics_peer.first = pkt_timestamp;
+            flow_metrics_peer.first = pkt_timestamp.into();
         }
 
         if meta_packet.vlan > 0 {
@@ -1379,8 +1380,8 @@ impl FlowMap {
         } else {
             flow.update_close_type(node.flow_state);
         }
-        flow.end_time = timeout;
-        flow.flow_stat_time = Duration::from_nanos(
+        flow.end_time = timeout.into();
+        flow.flow_stat_time = Timestamp::from_nanos(
             (timeout.as_nanos() / STATISTICAL_INTERVAL.as_nanos() * STATISTICAL_INTERVAL.as_nanos())
                 as u64,
         );
@@ -1400,6 +1401,7 @@ impl FlowMap {
                     flow.signal_source == SignalSource::Packet && Self::l4_metrics_enabled(config),
                     Self::l7_metrics_enabled(config),
                 )
+                .map(|o| Box::new(o))
             });
         }
 
@@ -1448,6 +1450,7 @@ impl FlowMap {
                             && Self::l4_metrics_enabled(config),
                         Self::l7_metrics_enabled(config),
                     )
+                    .map(|o| Box::new(o))
                 });
             }
             self.push_to_flow_stats_queue(config, node.tagged_flow.clone());

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -73,7 +73,6 @@ use crate::{
     rpc::get_timestamp,
     utils::stats::{self, Countable, StatsOption},
 };
-use npb_pcap_policy::PolicyData;
 use public::{
     counter::{Counter, CounterType, CounterValue, RefCountable},
     debug::QueueDebugger,
@@ -81,6 +80,9 @@ use public::{
     queue::{self, DebugSender, Receiver},
     utils::net::MacAddr,
 };
+
+use npb_pcap_policy::PolicyData;
+use packet_sequence_block::PacketSequenceBlock;
 
 // not thread-safe
 pub struct FlowMap {
@@ -110,7 +112,7 @@ pub struct FlowMap {
     rrt_cache: Rc<RefCell<L7RrtCache>>,
     flow_perf_counter: Arc<FlowPerfCounter>,
     ntp_diff: Arc<AtomicI64>,
-    packet_sequence_queue: Option<DebugSender<Box<packet_sequence_block::PacketSequenceBlock>>>, // Enterprise Edition Feature: packet-sequence
+    packet_sequence_queue: Option<DebugSender<Box<PacketSequenceBlock>>>, // Enterprise Edition Feature: packet-sequence
     packet_sequence_enabled: bool,
     stats_counter: Arc<FlowMapCounter>,
 
@@ -129,7 +131,7 @@ impl FlowMap {
         config: FlowAccess,
         parse_config: LogParserAccess,
         #[cfg(target_os = "linux")] ebpf_config: Option<EbpfAccess>,
-        packet_sequence_queue: Option<DebugSender<Box<packet_sequence_block::PacketSequenceBlock>>>, // Enterprise Edition Feature: packet-sequence
+        packet_sequence_queue: Option<DebugSender<Box<PacketSequenceBlock>>>, // Enterprise Edition Feature: packet-sequence
         stats_collector: &stats::Collector,
         from_ebpf: bool,
     ) -> Self {
@@ -333,17 +335,15 @@ impl FlowMap {
                     // 未超时Flow的统计信息发送到队列下游
                     self.node_updated_aftercare(&config, node, timestamp, None);
                     // Enterprise Edition Feature: packet-sequence
-                    if self.packet_sequence_enabled && node.packet_sequence_block.is_some() {
-                        // flush the packet_sequence_block at the regular time
-                        if let Err(_) = self
-                            .packet_sequence_queue
-                            .as_ref()
-                            .unwrap()
-                            .send(Box::new(node.packet_sequence_block.take().unwrap()))
-                        {
-                            warn!(
-                                "packet sequence block to queue failed maybe queue have terminated"
-                            );
+                    if self.packet_sequence_enabled {
+                        if let Some(block) = node.packet_sequence_block.take() {
+                            // flush the packet_sequence_block at the regular time
+                            if let Err(_) = self.packet_sequence_queue.as_ref().unwrap().send(block)
+                            {
+                                warn!(
+                                    "packet sequence block to queue failed maybe queue have terminated"
+                                );
+                            }
                         }
                     }
 
@@ -522,18 +522,18 @@ impl FlowMap {
                     .packet_sequence_queue
                     .as_ref()
                     .unwrap()
-                    .send(Box::new(node.packet_sequence_block.take().unwrap()))
+                    .send(node.packet_sequence_block.take().unwrap())
                 {
                     warn!("packet sequence block to queue failed maybe queue have terminated");
                 }
-                node.packet_sequence_block = Some(packet_sequence_block::PacketSequenceBlock::new(
+                node.packet_sequence_block = Some(Box::new(PacketSequenceBlock::new(
                     (meta_packet.lookup_key.timestamp.as_secs() / MINUTE) as u32,
-                ));
+                )));
             }
         } else {
-            node.packet_sequence_block = Some(packet_sequence_block::PacketSequenceBlock::new(
+            node.packet_sequence_block = Some(Box::new(PacketSequenceBlock::new(
                 (meta_packet.lookup_key.timestamp.as_secs() / MINUTE) as u32,
-            ));
+            )));
         }
 
         let mini_meta_packet = packet_sequence_block::MiniMetaPacket::new(
@@ -967,6 +967,7 @@ impl FlowMap {
                 get_parser(l7_proto_enum.unwrap_or_default()),
                 self.flow_perf_counter.clone(),
             )
+            .map(|o| Box::new(o));
         }
         node
     }
@@ -1403,17 +1404,11 @@ impl FlowMap {
         }
 
         // Enterprise Edition Feature: packet-sequence
-        if self.packet_sequence_enabled
-            && node.packet_sequence_block.is_some()
-            && flow.flow_key.proto == IpProtocol::Tcp
-        {
-            if let Err(_) = self
-                .packet_sequence_queue
-                .as_ref()
-                .unwrap()
-                .send(Box::new(node.packet_sequence_block.take().unwrap()))
-            {
-                warn!("packet sequence block to queue failed maybe queue have terminated");
+        if self.packet_sequence_enabled && flow.flow_key.proto == IpProtocol::Tcp {
+            if let Some(block) = node.packet_sequence_block.take() {
+                if let Err(_) = self.packet_sequence_queue.as_ref().unwrap().send(block) {
+                    warn!("packet sequence block to queue failed maybe queue have terminated");
+                }
             }
         }
 

--- a/agent/src/flow_generator/flow_map.rs
+++ b/agent/src/flow_generator/flow_map.rs
@@ -42,7 +42,7 @@ use super::{
     perf::{FlowPerf, FlowPerfCounter, L7ProtocolChecker, L7RrtCache},
     protocol_logs::MetaAppProto,
     service_table::{ServiceKey, ServiceTable},
-    FlowMapKey, FlowNode, FlowState, COUNTER_FLOW_ID_MASK, FLOW_METRICS_PEER_DST,
+    FlowMapKey, FlowNode, FlowState, FlowTimeout, COUNTER_FLOW_ID_MASK, FLOW_METRICS_PEER_DST,
     FLOW_METRICS_PEER_SRC, L7_PROTOCOL_UNKNOWN_LIMIT, L7_RRT_CACHE_CAPACITY, QUEUE_BATCH_SIZE,
     SERVICE_TABLE_IPV4_CAPACITY, SERVICE_TABLE_IPV6_CAPACITY, STATISTICAL_INTERVAL,
     THREAD_FLOW_ID_MASK, TIMER_FLOW_ID_MASK, TIME_UNIT,
@@ -294,7 +294,10 @@ impl FlowMap {
             .take()
             .unwrap_or(Vec::with_capacity(self.hash_slots / self.time_window_size));
         moved_key.clear();
-        for time_in_unit in self.start_time_in_unit..next_start_time_in_unit {
+        // at most self.time_windows_size slots in time_set
+        for time_in_unit in self.start_time_in_unit
+            ..next_start_time_in_unit.min(self.start_time_in_unit + self.time_window_size as u64)
+        {
             let time_hashset = &mut time_set[time_in_unit as usize & (self.time_window_size - 1)];
             for flow_key in time_hashset.drain() {
                 let Some(nodes) = node_map.get_mut(&flow_key) else {
@@ -1789,6 +1792,7 @@ pub fn _reverse_meta_packet(packet: &mut MetaPacket) {
 
 pub fn _new_flow_map_and_receiver(
     trident_type: TridentType,
+    flow_timeout: Option<FlowTimeout>,
 ) -> (FlowMap, Receiver<Box<TaggedFlow>>) {
     let (_, mut policy_getter) = Policy::new(1, 0, 1 << 10, false);
     policy_getter.disable();
@@ -1804,6 +1808,7 @@ pub fn _new_flow_map_and_receiver(
             l4_performance_enabled: true,
             l7_metrics_enabled: true,
             app_proto_log_enabled: true,
+            flow_timeout: flow_timeout.unwrap_or(super::TcpTimeout::default().into()),
             ..(&RuntimeConfig::default()).into()
         },
         log_parser: LogParserConfig {
@@ -1930,10 +1935,17 @@ mod tests {
 
     const DEFAULT_DURATION: Duration = Duration::from_millis(10);
 
+    impl FlowMap {
+        fn reset_start_time(&mut self, d: Duration) {
+            self.start_time = d;
+            self.start_time_in_unit = (d.as_nanos() / TIME_UNIT.as_nanos()) as u64;
+        }
+    }
+
     #[test]
     fn syn_rst() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet0 = _new_meta_packet();
         flow_map.inject_meta_packet(&mut packet0);
         let mut packet1 = _new_meta_packet();
@@ -1962,7 +1974,7 @@ mod tests {
     #[test]
     fn syn_fin() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet0 = _new_meta_packet();
         flow_map.inject_meta_packet(&mut packet0);
 
@@ -1995,7 +2007,7 @@ mod tests {
     #[test]
     fn platform_data() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet1 = _new_meta_packet();
         packet1.tcp_data.seq = 1111;
         packet1.tcp_data.ack = 112;
@@ -2018,7 +2030,7 @@ mod tests {
     #[test]
     fn handshake_perf() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet0 = _new_meta_packet();
         packet0.tcp_data.flags = TcpFlags::SYN;
         packet0.tcp_data.seq = 111;
@@ -2051,7 +2063,7 @@ mod tests {
 
     #[test]
     fn reverse_new_cycle() {
-        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess);
+        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let npb_action = NpbAction::new(
             0,
             10,
@@ -2097,7 +2109,7 @@ mod tests {
     #[test]
     fn force_report() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet0 = _new_meta_packet();
         flow_map.inject_meta_packet(&mut packet0);
 
@@ -2130,7 +2142,7 @@ mod tests {
     #[test]
     fn udp_arp_short_flow() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut packet0 = _new_meta_packet();
         packet0.lookup_key.proto = IpProtocol::Udp;
         let flush_timestamp = packet0.lookup_key.timestamp;
@@ -2159,7 +2171,7 @@ mod tests {
     #[test]
     fn port_equal_tor() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtHyperVCompute);
+            _new_flow_map_and_receiver(TridentType::TtHyperVCompute, None);
         let mut packet0 = _new_meta_packet();
         packet0.lookup_key.tap_type = TapType::Cloud;
         flow_map.inject_meta_packet(&mut packet0);
@@ -2212,7 +2224,7 @@ mod tests {
 
     #[test]
     fn flow_state_machine() {
-        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess);
+        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess, None);
 
         let config = (&RuntimeConfig::default()).into();
 
@@ -2275,7 +2287,7 @@ mod tests {
     #[test]
     fn double_fin_from_server() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
         // SYN
         let mut packet0 = _new_meta_packet();
         packet0.lookup_key.timestamp = Duration::from_nanos(
@@ -2321,8 +2333,20 @@ mod tests {
 
     #[test]
     fn l3_l4_payload() {
-        let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+        let (mut flow_map, output_queue_receiver) = _new_flow_map_and_receiver(
+            TridentType::TtProcess,
+            Some(FlowTimeout {
+                opening: Duration::ZERO,
+                established: Duration::from_secs(300),
+                closing: Duration::ZERO,
+                established_rst: Duration::from_secs(30),
+                exception: Duration::from_secs(5),
+                closed_fin: Duration::ZERO,
+                single_direction: Duration::from_millis(10),
+                max: Duration::from_secs(300),
+                min: Duration::ZERO,
+            }),
+        );
 
         let capture = Capture::load_pcap("resources/test/flow_generator/ip-fragment.pcap", None);
         let packets = capture.as_meta_packets();
@@ -2359,11 +2383,12 @@ mod tests {
     #[test]
     fn tcp_perf() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
 
         let capture = Capture::load_pcap("resources/test/flow_generator/http.pcap", None);
         let packets = capture.as_meta_packets();
 
+        flow_map.reset_start_time(packets[0].lookup_key.timestamp);
         let dst_mac = packets[0].lookup_key.dst_mac;
         let timestamp = time::SystemTime::now()
             .duration_since(time::UNIX_EPOCH)
@@ -2389,7 +2414,7 @@ mod tests {
     #[test]
     fn tcp_syn_ack_zerowin() {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
 
         let capture = Capture::load_pcap(
             "resources/test/flow_generator/tcp-syn-ack-zerowin.pcap",
@@ -2397,6 +2422,7 @@ mod tests {
         );
         let packets = capture.as_meta_packets();
 
+        flow_map.reset_start_time(packets[0].lookup_key.timestamp);
         let timestamp = time::SystemTime::now()
             .duration_since(time::UNIX_EPOCH)
             .unwrap();

--- a/agent/src/flow_generator/flow_node.rs
+++ b/agent/src/flow_generator/flow_node.rs
@@ -27,9 +27,11 @@ use crate::common::{
     tagged_flow::TaggedFlow,
     TapPort,
 };
-use npb_pcap_policy::PolicyData;
 use public::proto::common::TridentType;
 use public::utils::net::MacAddr;
+
+use npb_pcap_policy::PolicyData;
+use packet_sequence_block::PacketSequenceBlock;
 
 #[repr(u8)]
 enum MatchMac {
@@ -124,7 +126,7 @@ pub struct FlowNode {
     // 用作time_set比对的标识，等于FlowTimeKey的timestamp_key, 只有创建FlowNode和刷新更新流节点的超时才会更新
     pub timestamp_key: u64,
 
-    pub meta_flow_perf: Option<FlowPerf>,
+    pub meta_flow_perf: Option<Box<FlowPerf>>,
     pub policy_data_cache: [PolicyData; 2],
     pub endpoint_data_cache: [Arc<EndpointData>; 2],
 
@@ -138,7 +140,7 @@ pub struct FlowNode {
     pub flow_state: FlowState,
 
     // Enterprise Edition Feature: packet-sequence
-    pub packet_sequence_block: Option<packet_sequence_block::PacketSequenceBlock>,
+    pub packet_sequence_block: Option<Box<PacketSequenceBlock>>,
 }
 
 impl FlowNode {

--- a/agent/src/flow_generator/flow_node.rs
+++ b/agent/src/flow_generator/flow_node.rs
@@ -148,7 +148,7 @@ impl FlowNode {
         self.policy_in_tick = [false; 2];
         self.packet_in_tick = false;
         let flow = &mut self.tagged_flow.flow;
-        flow.flow_stat_time = Duration::ZERO;
+        flow.flow_stat_time = Default::default();
         flow.is_new_flow = false;
         let flow_metrics_peer_src = &mut flow.flow_metrics_peers[FLOW_METRICS_PEER_SRC];
         flow_metrics_peer_src.packet_count = 0;

--- a/agent/src/flow_generator/flow_state.rs
+++ b/agent/src/flow_generator/flow_state.rs
@@ -733,7 +733,7 @@ mod tests {
 
     #[test]
     fn state_machine() {
-        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess);
+        let (mut flow_map, _) = _new_flow_map_and_receiver(TridentType::TtProcess, None);
         let mut flow_node = FlowNode {
             timestamp_key: get_timestamp(0).as_nanos() as u64,
 
@@ -809,7 +809,7 @@ mod tests {
 
     fn state_machine_helper<P: AsRef<Path>>(pcap_file: P, expect_close_type: CloseType) {
         let (mut flow_map, output_queue_receiver) =
-            _new_flow_map_and_receiver(TridentType::TtProcess);
+            _new_flow_map_and_receiver(TridentType::TtProcess, None);
 
         let capture = Capture::load_pcap(pcap_file, None);
         let packets = capture.as_meta_packets();

--- a/agent/src/flow_generator/flow_state.rs
+++ b/agent/src/flow_generator/flow_state.rs
@@ -706,6 +706,8 @@ mod tests {
     use crate::utils::test::Capture;
     use public::proto::common::TridentType;
 
+    use packet_sequence_block::PacketSequenceBlock;
+
     const FILE_DIR: &'static str = "resources/test/flow_generator";
 
     #[test]
@@ -778,7 +780,7 @@ mod tests {
             next_tcp_seq1: 0,
             packet_in_tick: false,
             policy_in_tick: [false; 2],
-            packet_sequence_block: Some(packet_sequence_block::PacketSequenceBlock::default()), // Enterprise Edition Feature: packet-sequence
+            packet_sequence_block: Some(Box::new(PacketSequenceBlock::default())), // Enterprise Edition Feature: packet-sequence
         };
 
         let peers = &mut flow_node.tagged_flow.flow.flow_metrics_peers;

--- a/agent/src/flow_generator/mod.rs
+++ b/agent/src/flow_generator/mod.rs
@@ -18,8 +18,8 @@ mod app_table;
 mod error;
 mod flow_config;
 pub mod flow_map;
-mod flow_node;
-mod flow_state;
+pub(crate) mod flow_node;
+pub(crate) mod flow_state;
 mod packet_sequence; // Enterprise Edition Feature: packet-sequence
 pub mod perf;
 pub mod protocol_logs;

--- a/agent/src/flow_generator/perf/http.rs
+++ b/agent/src/flow_generator/perf/http.rs
@@ -493,7 +493,7 @@ impl HttpPerfData {
     }
 
     fn parse_go_http2_uprobe(&mut self, payload: &[u8], param: &ParseParam) -> Result<()> {
-        let mut log = L7ProtocolParser::HttpParser(HttpLog::new_v2(false));
+        let mut log = L7ProtocolParser::Http(Box::new(HttpLog::new_v2(false)));
         let perf_stats = self.perf_stats.get_or_insert(PerfStats::default());
         if let L7ProtocolInfo::HttpInfo(h) = log.parse_payload(payload, param)?.get(0).unwrap() {
             self.session_data.httpv2_headers.stream_id = h.stream_id.unwrap_or_default();

--- a/agent/src/flow_generator/perf/mod.rs
+++ b/agent/src/flow_generator/perf/mod.rs
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-mod dns;
+pub(crate) mod dns;
 pub mod http;
 pub mod l7_rrt;
-mod mq;
-mod rpc;
-mod sql;
+pub(crate) mod mq;
+pub(crate) mod rpc;
+pub(crate) mod sql;
 mod stats;
 pub mod tcp;
-mod udp;
+pub(crate) mod udp;
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -70,14 +70,13 @@ pub use dns::DNS_PORT;
 
 const ART_MAX: Duration = Duration::from_secs(30);
 
-#[enum_dispatch(L4FlowPerfTable)]
 pub trait L4FlowPerf {
     fn parse(&mut self, packet: &MetaPacket, direction: bool) -> Result<()>;
     fn data_updated(&self) -> bool;
     fn copy_and_reset_data(&mut self, flow_reversed: bool) -> FlowPerfStats;
 }
 
-#[enum_dispatch(L7FlowPerfTable)]
+#[enum_dispatch]
 pub trait L7FlowPerf {
     fn parse(
         &mut self,
@@ -90,33 +89,96 @@ pub trait L7FlowPerf {
     fn app_proto_head(&mut self) -> Option<(AppProtoHead, u16)>;
 }
 
-#[enum_dispatch]
 pub enum L4FlowPerfTable {
-    TcpPerf,
-    UdpPerf,
+    Tcp(Box<TcpPerf>),
+    Udp(UdpPerf),
 }
 
-#[enum_dispatch]
-pub enum L7FlowPerfTable {
-    DnsPerfData,
-    KafkaPerfData,
-    MqttPerfData,
-    RedisPerfData,
-    DubboPerfData,
-    MysqlPerfData,
-    HttpPerfData,
-    PostgresqlLog,
-    ProtobufRpcWrapLog,
-    SofaRpcLog,
+impl L4FlowPerf for L4FlowPerfTable {
+    fn parse(&mut self, packet: &MetaPacket, direction: bool) -> Result<()> {
+        match self {
+            Self::Tcp(p) => p.parse(packet, direction),
+            Self::Udp(p) => p.parse(packet, direction),
+        }
+    }
+
+    fn data_updated(&self) -> bool {
+        match self {
+            Self::Tcp(p) => p.data_updated(),
+            Self::Udp(p) => p.data_updated(),
+        }
+    }
+
+    fn copy_and_reset_data(&mut self, flow_reversed: bool) -> FlowPerfStats {
+        match self {
+            Self::Tcp(p) => p.copy_and_reset_data(flow_reversed),
+            Self::Udp(p) => p.copy_and_reset_data(flow_reversed),
+        }
+    }
+}
+
+macro_rules! impl_l7_flow_perf {
+    (pub enum $name:ident { $($enum_name:ident($enum_type:ty)),* $(,)? }) => {
+        pub enum $name {
+            $($enum_name($enum_type)),*
+        }
+
+        impl L7FlowPerf for $name {
+            fn parse(
+                &mut self,
+                config: Option<&LogParserConfig>,
+                packet: &MetaPacket,
+                flow_id: u64,
+            ) -> Result<()> {
+                match self {
+                    $(Self::$enum_name(p) => p.parse(config, packet, flow_id)),*
+                }
+            }
+
+            fn data_updated(&self) -> bool {
+                match self {
+                    $(Self::$enum_name(p) => p.data_updated()),*
+                }
+            }
+
+            fn copy_and_reset_data(&mut self, l7_timeout_count: u32) -> FlowPerfStats {
+                match self {
+                    $(Self::$enum_name(p) => p.copy_and_reset_data(l7_timeout_count)),*
+                }
+            }
+
+            fn app_proto_head(&mut self) -> Option<(AppProtoHead, u16)> {
+                match self {
+                    $(Self::$enum_name(p) => p.app_proto_head()),*
+                }
+            }
+        }
+    };
+}
+
+// impl L7FlowPerf for L7FlowPerfTable
+impl_l7_flow_perf! {
+    pub enum L7FlowPerfTable {
+        Dns(DnsPerfData),
+        Kafka(KafkaPerfData),
+        Mqtt(MqttPerfData),
+        Redis(RedisPerfData),
+        Dubbo(DubboPerfData),
+        Mysql(MysqlPerfData),
+        Http(HttpPerfData),
+        Postgresql(Box<PostgresqlLog>),
+        ProtobufRpc(Box<ProtobufRpcWrapLog>),
+        SofaRpc(Box<SofaRpcLog>),
+    }
 }
 
 impl L7FlowPerfTable {
     // TODO will remove when perf abstruct to log parse
     pub fn reset(&mut self) {
         match self {
-            L7FlowPerfTable::ProtobufRpcWrapLog(p) => p.reset(),
-            L7FlowPerfTable::PostgresqlLog(p) => p.reset(),
-            L7FlowPerfTable::SofaRpcLog(p) => p.reset(),
+            L7FlowPerfTable::ProtobufRpc(p) => p.reset(),
+            L7FlowPerfTable::Postgresql(p) => p.reset(),
+            L7FlowPerfTable::SofaRpc(p) => p.reset(),
             _ => {}
         }
     }
@@ -215,20 +277,28 @@ impl FlowPerf {
 
     fn l7_new(protocol: L7Protocol, rrt_cache: Rc<RefCell<L7RrtCache>>) -> Option<L7FlowPerfTable> {
         match protocol {
-            L7Protocol::DNS => Some(L7FlowPerfTable::from(DnsPerfData::new(rrt_cache.clone()))),
-            L7Protocol::ProtobufRPC => Some(L7FlowPerfTable::from(ProtobufRpcWrapLog::new())),
-            L7Protocol::SofaRPC => Some(L7FlowPerfTable::from(SofaRpcLog::new())),
-            L7Protocol::Dubbo => Some(L7FlowPerfTable::from(DubboPerfData::new(rrt_cache.clone()))),
-            L7Protocol::Kafka => Some(L7FlowPerfTable::from(KafkaPerfData::new(rrt_cache.clone()))),
-            L7Protocol::MQTT => Some(L7FlowPerfTable::from(MqttPerfData::new(rrt_cache.clone()))),
-            L7Protocol::MySQL => Some(L7FlowPerfTable::from(MysqlPerfData::new(rrt_cache.clone()))),
-            L7Protocol::PostgreSQL => Some(L7FlowPerfTable::from(PostgresqlLog::new())),
-            L7Protocol::Redis => Some(L7FlowPerfTable::from(RedisPerfData::new(rrt_cache.clone()))),
+            L7Protocol::DNS => Some(L7FlowPerfTable::Dns(DnsPerfData::new(rrt_cache.clone()))),
+            L7Protocol::ProtobufRPC => Some(L7FlowPerfTable::ProtobufRpc(Default::default())),
+            L7Protocol::SofaRPC => Some(L7FlowPerfTable::SofaRpc(Default::default())),
+            L7Protocol::Dubbo => Some(L7FlowPerfTable::Dubbo(DubboPerfData::new(
+                rrt_cache.clone(),
+            ))),
+            L7Protocol::Kafka => Some(L7FlowPerfTable::Kafka(KafkaPerfData::new(
+                rrt_cache.clone(),
+            ))),
+            L7Protocol::MQTT => Some(L7FlowPerfTable::Mqtt(MqttPerfData::new(rrt_cache.clone()))),
+            L7Protocol::MySQL => Some(L7FlowPerfTable::Mysql(MysqlPerfData::new(
+                rrt_cache.clone(),
+            ))),
+            L7Protocol::PostgreSQL => Some(L7FlowPerfTable::Postgresql(Default::default())),
+            L7Protocol::Redis => Some(L7FlowPerfTable::Redis(RedisPerfData::new(
+                rrt_cache.clone(),
+            ))),
             L7Protocol::Http1
             | L7Protocol::Http1TLS
             | L7Protocol::Http2
             | L7Protocol::Http2TLS
-            | L7Protocol::Grpc => Some(L7FlowPerfTable::from(HttpPerfData::new(rrt_cache.clone()))),
+            | L7Protocol::Grpc => Some(L7FlowPerfTable::Http(HttpPerfData::new(rrt_cache.clone()))),
             _ => None,
         }
     }
@@ -532,8 +602,8 @@ impl FlowPerf {
         counter: Arc<FlowPerfCounter>,
     ) -> Option<Self> {
         let l4 = match l4_proto {
-            L4Protocol::Tcp => L4FlowPerfTable::from(TcpPerf::new(counter)),
-            L4Protocol::Udp => L4FlowPerfTable::from(UdpPerf::new()),
+            L4Protocol::Tcp => L4FlowPerfTable::Tcp(Box::new(TcpPerf::new(counter))),
+            L4Protocol::Udp => L4FlowPerfTable::Udp(UdpPerf::new()),
             _ => {
                 return None;
             }

--- a/agent/src/flow_generator/perf/mod.rs
+++ b/agent/src/flow_generator/perf/mod.rs
@@ -191,10 +191,10 @@ impl<'a> Iterator for L7ProtocolCheckerIterator<'a> {
 
 pub struct FlowPerf {
     l4: L4FlowPerfTable,
-    l7: Option<L7FlowPerfTable>,
+    l7: Option<Box<L7FlowPerfTable>>,
 
     // perf 目前还没有抽象出来,自定义协议需要添加字段区分,以后抽出来后 l7可以去掉.
-    l7_protocol_log_parser: Option<L7ProtocolParser>,
+    l7_protocol_log_parser: Option<Box<L7ProtocolParser>>,
 
     rrt_cache: Rc<RefCell<L7RrtCache>>,
 
@@ -403,7 +403,8 @@ impl FlowPerf {
                     let mut rrt = 0;
                     if is_parse_perf {
                         // perf 没有抽象出来,这里可能返回None，对于返回None即不解析perf，只解析log
-                        self.l7 = Self::l7_new(*protocol, self.rrt_cache.clone());
+                        self.l7 =
+                            Self::l7_new(*protocol, self.rrt_cache.clone()).map(|o| Box::new(o));
                         if self.l7.is_some() {
                             rrt = self.l7_parse_perf(
                                 log_parser_config,
@@ -417,7 +418,7 @@ impl FlowPerf {
                     }
 
                     if is_parse_log {
-                        self.l7_protocol_log_parser = Some(parser);
+                        self.l7_protocol_log_parser = Some(Box::new(parser));
                         let ret = self.l7_parse_log(
                             flow_config,
                             packet,
@@ -542,8 +543,9 @@ impl FlowPerf {
 
         Some(Self {
             l4,
-            l7: Self::l7_new(l7_protocol_enum.get_l7_protocol(), rrt_cache.clone()),
-            l7_protocol_log_parser: l7_parser,
+            l7: Self::l7_new(l7_protocol_enum.get_l7_protocol(), rrt_cache.clone())
+                .map(|o| Box::new(o)),
+            l7_protocol_log_parser: l7_parser.map(|o| Box::new(o)),
             rrt_cache,
             l7_protocol_enum,
             is_from_app: l7_proto.is_some(),
@@ -558,7 +560,7 @@ impl FlowPerf {
         self.is_from_app = l7_proto.is_some();
         self.is_skip = false;
         self.is_success = false;
-        self.l7 = Self::l7_new(l7_protocol, self.rrt_cache.clone());
+        self.l7 = Self::l7_new(l7_protocol, self.rrt_cache.clone()).map(|o| Box::new(o));
     }
 
     pub fn parse(

--- a/agent/src/flow_generator/perf/mod.rs
+++ b/agent/src/flow_generator/perf/mod.rs
@@ -29,7 +29,6 @@ use std::collections::HashMap;
 use std::rc::Rc;
 use std::slice;
 use std::sync::Arc;
-use std::time::Duration;
 
 use enum_dispatch::enum_dispatch;
 use public::bitmap::Bitmap;
@@ -48,6 +47,7 @@ use crate::{
             L7ProtocolParserInterface, ParseParam,
         },
         meta_packet::MetaPacket,
+        Timestamp,
     },
     config::{handler::LogParserConfig, FlowConfig},
 };
@@ -68,7 +68,7 @@ pub use stats::PerfStats;
 
 pub use dns::DNS_PORT;
 
-const ART_MAX: Duration = Duration::from_secs(30);
+const ART_MAX: Timestamp = Timestamp::from_secs(30);
 
 pub trait L4FlowPerf {
     fn parse(&mut self, packet: &MetaPacket, direction: bool) -> Result<()>;

--- a/agent/src/flow_generator/perf/tcp.rs
+++ b/agent/src/flow_generator/perf/tcp.rs
@@ -29,17 +29,18 @@ use crate::{
         flow::{FlowPerfStats, L4Protocol},
         lookup_key::LookupKey,
         meta_packet::{MetaPacket, MetaPacketTcpHeader},
+        Timestamp,
     },
     flow_generator::error::{Error, Result},
 };
 
-const SRT_MAX: Duration = Duration::from_secs(10);
-const RTT_FULL_MAX: Duration = Duration::from_secs(30);
-const RTT_MAX: Duration = Duration::from_secs(30);
+const SRT_MAX: Timestamp = Timestamp::from_secs(10);
+const RTT_FULL_MAX: Timestamp = Timestamp::from_secs(30);
+const RTT_MAX: Timestamp = Timestamp::from_secs(30);
 
-fn adjust_rtt(d: Duration, max: Duration) -> Duration {
+fn adjust_rtt(d: Timestamp, max: Timestamp) -> Timestamp {
     if d > max {
-        Duration::ZERO
+        Timestamp::ZERO
     } else {
         d
     }
@@ -84,8 +85,8 @@ pub(crate) struct SessionPeer {
     seq_list: [SeqSegment; SEQ_LIST_MAX_LEN],
     seq_list_len: isize,
 
-    timestamp: Duration,
-    first_syn_timestamp: Duration,
+    timestamp: Timestamp,
+    first_syn_timestamp: Timestamp,
 
     seq_threshold: u32, // fast syn_retrans check
     seq: u32,
@@ -337,7 +338,7 @@ impl SessionPeer {
     // 在TCP_STATE_ESTABLISHED阶段更新数据
     fn update_data(&mut self, p: &MetaPacket) {
         let header = &p.tcp_data;
-        self.timestamp = p.lookup_key.timestamp;
+        self.timestamp = p.lookup_key.timestamp.into();
         self.payload_len = p.payload_len as u32;
         if header.flags.contains(TcpFlags::SYN) {
             self.payload_len = 1;
@@ -355,27 +356,19 @@ impl fmt::Display for SessionPeer {
     }
 }
 
-struct PacketVariance {
-    interval_avg: f64,
-    interval_variance: f64,
-    size_avg: f64,
-    size_variance: f64,
-    last_timestamp: Duration,
-}
-
 #[derive(Default)]
 pub(crate) struct PerfControl(SessionPeer, SessionPeer);
 
 #[derive(Default, Debug, PartialEq, Eq)]
 struct TimeStats {
     pub count: u32,
-    pub sum: Duration,
-    pub max: Duration,
+    pub sum: Timestamp,
+    pub max: Timestamp,
     pub updated: bool,
 }
 
 impl TimeStats {
-    fn update(&mut self, d: Duration) {
+    fn update(&mut self, d: Timestamp) {
         self.count += 1;
         self.sum += d;
         if self.max < d {
@@ -400,7 +393,7 @@ pub(crate) struct PerfData {
 
     // flow数据
     retrans_sum: u32,
-    rtt_full: Duration,
+    rtt_full: Timestamp,
 
     // 包括syn重传
     retrans_0: u32,
@@ -431,7 +424,7 @@ impl PerfData {
 
     // FIXME: art,rtt均值计算方法，需要增加影响因子
     // 计算art值
-    fn calc_art(&mut self, d: Duration, fpd: bool) {
+    fn calc_art(&mut self, d: Timestamp, fpd: bool) {
         if fpd {
             self.art_0.update(d);
         } else {
@@ -441,7 +434,7 @@ impl PerfData {
     }
 
     // 计算srt值
-    fn calc_srt(&mut self, d: Duration, fpd: bool) {
+    fn calc_srt(&mut self, d: Timestamp, fpd: bool) {
         if fpd {
             self.srt_0.update(d);
         } else {
@@ -450,12 +443,12 @@ impl PerfData {
         self.updated = true;
     }
 
-    fn calc_rtt_full(&mut self, d: Duration) {
+    fn calc_rtt_full(&mut self, d: Timestamp) {
         self.rtt_full = d;
         self.updated = true;
     }
 
-    fn calc_rtt(&mut self, d: Duration, fpd: bool) {
+    fn calc_rtt(&mut self, d: Timestamp, fpd: bool) {
         if fpd {
             self.rtt_0.update(d);
         } else {
@@ -522,7 +515,7 @@ impl PerfData {
         self.updated = true;
     }
 
-    fn calc_cit(&mut self, d: Duration) {
+    fn calc_cit(&mut self, d: Timestamp) {
         self.cit.update(d);
         self.updated = true;
     }
@@ -620,7 +613,7 @@ impl TcpPerf {
             if same_dir.seq_threshold == 0 {
                 // first SYN
                 same_dir.seq_threshold = p.tcp_data.seq + 1;
-                same_dir.first_syn_timestamp = p.lookup_key.timestamp;
+                same_dir.first_syn_timestamp = p.lookup_key.timestamp.into();
                 self.handshaking = true;
             } else if same_dir.syn_transmitted {
                 self.perf_data.calc_retrans_syn(fpd);
@@ -724,7 +717,10 @@ impl TcpPerf {
             if (Self::is_handshake_ack_packet(same_dir, oppo_dir, p) || p.is_syn_ack())
                 && oppo_dir.is_reply_packet(p)
             {
-                let rtt = adjust_rtt(p.lookup_key.timestamp - oppo_dir.timestamp, RTT_MAX);
+                let rtt = adjust_rtt(
+                    (p.lookup_key.timestamp - oppo_dir.timestamp).into(),
+                    RTT_MAX,
+                );
                 if !rtt.is_zero() {
                     self.perf_data.calc_rtt(rtt, fpd);
                 }
@@ -734,7 +730,7 @@ impl TcpPerf {
         if same_dir.rtt_full_calculable {
             if oppo_dir.is_sync_ack_ack_packet(p) {
                 let rtt_full = adjust_rtt(
-                    p.lookup_key.timestamp - same_dir.first_syn_timestamp,
+                    (p.lookup_key.timestamp - same_dir.first_syn_timestamp).into(),
                     RTT_FULL_MAX,
                 );
                 if !rtt_full.is_zero() {
@@ -786,7 +782,10 @@ impl TcpPerf {
         // srt--用连续的PSH/ACK(payload_len>0)和反向ACK(payload_len==0)计算srt值
         if same_dir.srt_calculable {
             if p.is_ack() && oppo_dir.is_reply_packet(p) {
-                let srt = adjust_rtt(p.lookup_key.timestamp - oppo_dir.timestamp, SRT_MAX);
+                let srt = adjust_rtt(
+                    (p.lookup_key.timestamp - oppo_dir.timestamp).into(),
+                    SRT_MAX,
+                );
                 if !srt.is_zero() {
                     self.perf_data.calc_srt(srt, fpd);
                 }
@@ -796,7 +795,10 @@ impl TcpPerf {
         // art--用连续的PSH/ACK(payload_len>0)和ACK(payload_len==0)[可选]、PSH/ACK(payload_len>0)计算art值
         if same_dir.art_calculable {
             if p.has_valid_payload() && same_dir.is_next_packet(p) {
-                let art = adjust_rtt(p.lookup_key.timestamp - oppo_dir.timestamp, ART_MAX);
+                let art = adjust_rtt(
+                    (p.lookup_key.timestamp - oppo_dir.timestamp).into(),
+                    ART_MAX,
+                );
                 if !art.is_zero() {
                     self.perf_data.calc_art(art, fpd);
                 }
@@ -852,12 +854,12 @@ impl TcpPerf {
             if same_dir.is_handshake_ack_packet {
                 same_dir.is_handshake_ack_packet = false;
                 let d = p.lookup_key.timestamp - same_dir.timestamp.max(oppo_dir.timestamp);
-                self.perf_data.calc_cit(d);
+                self.perf_data.calc_cit(d.into());
             } else if oppo_dir.payload_len > 1
                 && (same_dir.payload_len <= 1 || oppo_dir.timestamp > same_dir.timestamp)
             {
                 let d = p.lookup_key.timestamp - oppo_dir.timestamp;
-                self.perf_data.calc_cit(d);
+                self.perf_data.calc_cit(d.into());
             }
         }
     }
@@ -995,19 +997,19 @@ impl fmt::Debug for TcpPerf {
 #[doc(hidden)]
 pub fn _benchmark_report(perf: &mut TcpPerf) {
     let pd = &mut perf.perf_data;
-    pd.art_0.max = Duration::from_nanos(100);
-    pd.art_0.sum = Duration::from_nanos(100);
+    pd.art_0.max = Timestamp::from_nanos(100);
+    pd.art_0.sum = Timestamp::from_nanos(100);
     pd.art_0.count = 1;
-    pd.art_1.max = Duration::from_nanos(300);
-    pd.art_1.sum = Duration::from_nanos(300);
+    pd.art_1.max = Timestamp::from_nanos(300);
+    pd.art_1.sum = Timestamp::from_nanos(300);
     pd.art_1.count = 1;
     let _ = perf.copy_and_reset_data(false);
     let pd = &mut perf.perf_data;
-    pd.art_0.max = Duration::from_nanos(200);
-    pd.art_0.sum = Duration::from_nanos(200);
+    pd.art_0.max = Timestamp::from_nanos(200);
+    pd.art_0.sum = Timestamp::from_nanos(200);
     pd.art_0.count = 1;
-    pd.srt_0.max = Duration::from_nanos(1000);
-    pd.srt_0.sum = Duration::from_nanos(1000);
+    pd.srt_0.max = Timestamp::from_nanos(1000);
+    pd.srt_0.sum = Timestamp::from_nanos(1000);
     pd.srt_0.count = 1;
     let _ = perf.copy_and_reset_data(false);
 }
@@ -1266,13 +1268,13 @@ mod tests {
     fn adjust() {
         assert_eq!(adjust_rtt(SRT_MAX, SRT_MAX), SRT_MAX);
         assert_eq!(
-            adjust_rtt(SRT_MAX + Duration::from_secs(1), SRT_MAX),
-            Duration::ZERO
+            adjust_rtt(SRT_MAX + Timestamp::from_secs(1), SRT_MAX),
+            Timestamp::ZERO
         );
         assert_eq!(adjust_rtt(ART_MAX, ART_MAX), ART_MAX);
         assert_eq!(
-            adjust_rtt(ART_MAX + Duration::from_secs(1), ART_MAX),
-            Duration::ZERO
+            adjust_rtt(ART_MAX + Timestamp::from_secs(1), ART_MAX),
+            Timestamp::ZERO
         );
     }
 
@@ -1785,27 +1787,27 @@ mod tests {
 
         let perf_data = PerfData {
             rtt_0: TimeStats {
-                sum: Duration::from_nanos(10),
-                max: Duration::from_nanos(2),
+                sum: Timestamp::from_nanos(10),
+                max: Timestamp::from_nanos(2),
                 updated: true,
                 ..Default::default()
             },
             rtt_1: TimeStats {
-                sum: Duration::from_nanos(1),
-                max: Duration::from_nanos(1),
+                sum: Timestamp::from_nanos(1),
+                max: Timestamp::from_nanos(1),
                 updated: true,
                 ..Default::default()
             },
             art_0: TimeStats {
-                sum: Duration::from_nanos(70),
-                max: Duration::from_nanos(70),
+                sum: Timestamp::from_nanos(70),
+                max: Timestamp::from_nanos(70),
                 count: 1,
                 updated: true,
                 ..Default::default()
             },
             srt_0: TimeStats {
-                sum: Duration::from_nanos(16),
-                max: Duration::from_nanos(16),
+                sum: Timestamp::from_nanos(16),
+                max: Timestamp::from_nanos(16),
                 count: 2,
                 updated: true,
                 ..Default::default()

--- a/agent/src/flow_generator/perf/tcp.rs
+++ b/agent/src/flow_generator/perf/tcp.rs
@@ -80,7 +80,7 @@ struct SeqSegment {
 const SEQ_LIST_MAX_LEN: usize = 16;
 
 #[derive(Default)]
-struct SessionPeer {
+pub(crate) struct SessionPeer {
     seq_list: [SeqSegment; SEQ_LIST_MAX_LEN],
     seq_list_len: isize,
 
@@ -364,7 +364,7 @@ struct PacketVariance {
 }
 
 #[derive(Default)]
-struct PerfControl(SessionPeer, SessionPeer);
+pub(crate) struct PerfControl(SessionPeer, SessionPeer);
 
 #[derive(Default, Debug, PartialEq, Eq)]
 struct TimeStats {
@@ -389,7 +389,7 @@ impl TimeStats {
 // 现有3个连续包PSH/ACK--ACK--PSH/ACK,其中第一个包是client端的请求包，
 // 后2个包是server端的应答包，art表示后2个包之间的时间间隔
 #[derive(Default, Debug, PartialEq, Eq)]
-struct PerfData {
+pub(crate) struct PerfData {
     rtt_0: TimeStats,
     rtt_1: TimeStats,
     art_0: TimeStats,

--- a/agent/src/flow_generator/protocol_logs/mod.rs
+++ b/agent/src/flow_generator/protocol_logs/mod.rs
@@ -15,13 +15,13 @@
  */
 
 pub mod consts;
-mod dns;
-mod http;
-mod mq;
+pub(crate) mod dns;
+pub(crate) mod http;
+pub(crate) mod mq;
 mod parser;
 pub mod pb_adapter;
-mod rpc;
-mod sql;
+pub(crate) mod rpc;
+pub(crate) mod sql;
 pub use self::http::{
     check_http_method, get_http_request_info, get_http_request_version, get_http_resp_info,
     is_http_v1_payload, parse_v1_headers, HttpInfo, HttpLog, Httpv2Headers,

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -364,7 +364,9 @@ impl KafkaLog {
         if payload.len() < KAFKA_REQ_HEADER_LEN {
             return false;
         }
-        let mut kafka = KafkaLog { info: KafkaInfo::default() };
+        let mut kafka = KafkaLog {
+            info: KafkaInfo::default(),
+        };
 
         let ret = kafka.request(payload, true);
         if ret.is_err() {
@@ -429,7 +431,9 @@ mod tests {
                 None => continue,
             };
 
-            let mut kafka = KafkaLog { info: KafkaInfo::default() };
+            let mut kafka = KafkaLog {
+                info: KafkaInfo::default(),
+            };
             let _ = kafka.parse(
                 payload,
                 packet.lookup_key.proto,

--- a/agent/src/flow_generator/protocol_logs/mq/kafka.rs
+++ b/agent/src/flow_generator/protocol_logs/mq/kafka.rs
@@ -243,7 +243,7 @@ impl From<KafkaInfo> for L7ProtocolSendLog {
     }
 }
 
-#[derive(Clone, Debug, Default, Serialize)]
+#[derive(Clone, Serialize)]
 pub struct KafkaLog {
     info: KafkaInfo,
 }
@@ -278,18 +278,23 @@ impl L7ProtocolParserInterface for KafkaLog {
     }
 
     fn reset(&mut self) {
-        *self = Self::default();
+        self.info = KafkaInfo::default();
         self.info.status = L7ResponseStatus::NotExist;
     }
 }
-impl KafkaLog {
-    const MSG_LEN_SIZE: usize = 4;
 
-    pub fn new() -> KafkaLog {
-        let mut log = KafkaLog::default();
+impl Default for KafkaLog {
+    fn default() -> Self {
+        let mut log = KafkaLog {
+            info: KafkaInfo::default(),
+        };
         log.reset();
         log
     }
+}
+
+impl KafkaLog {
+    const MSG_LEN_SIZE: usize = 4;
 
     fn reset_logs(&mut self) {
         self.info.correlation_id = 0;
@@ -359,7 +364,7 @@ impl KafkaLog {
         if payload.len() < KAFKA_REQ_HEADER_LEN {
             return false;
         }
-        let mut kafka = KafkaLog::default();
+        let mut kafka = KafkaLog { info: KafkaInfo::default() };
 
         let ret = kafka.request(payload, true);
         if ret.is_err() {
@@ -424,7 +429,7 @@ mod tests {
                 None => continue,
             };
 
-            let mut kafka = KafkaLog::default();
+            let mut kafka = KafkaLog { info: KafkaInfo::default() };
             let _ = kafka.parse(
                 payload,
                 packet.lookup_key.proto,

--- a/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/mod.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/mod.rs
@@ -58,7 +58,7 @@ pub fn get_protobuf_rpc_parser(proto: ProtobufRpcProtocol) -> L7ProtocolParser {
     match proto {
         ProtobufRpcProtocol::Krpc => p.set_rpc_parser(ProtobufRpcLog::KrpcLog(KrpcLog::default())),
     }
-    L7ProtocolParser::ProtobufRpcParser(p)
+    L7ProtocolParser::ProtobufRPC(Box::new(p))
 }
 
 // all protobuf rpc parser

--- a/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/protobuf_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/protobuf_rpc/protobuf_rpc.rs
@@ -37,10 +37,6 @@ pub struct ProtobufRpcWrapLog {
 }
 
 impl ProtobufRpcWrapLog {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     pub(crate) fn set_rpc_parser(&mut self, parser: ProtobufRpcLog) {
         self.parser = Some(parser);
     }

--- a/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
+++ b/agent/src/flow_generator/protocol_logs/rpc/sofa_rpc.rs
@@ -290,10 +290,6 @@ impl L7ProtocolParserInterface for SofaRpcLog {
 }
 
 impl SofaRpcLog {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
     fn parse_with_strict(
         &mut self,
         mut payload: &[u8],
@@ -623,7 +619,7 @@ mod test {
         let mut p = capture.as_meta_packets();
         p[0].lookup_key.direction = PacketDirection::ClientToServer;
         p[1].lookup_key.direction = PacketDirection::ServerToClient;
-        let mut parser = SofaRpcLog::new();
+        let mut parser = SofaRpcLog::default();
 
         let req_param = &mut ParseParam::from(&p[0]);
         let req_payload = p[0].get_l4_payload().unwrap();
@@ -677,7 +673,7 @@ mod test {
         let mut p = capture.as_meta_packets();
         p[0].lookup_key.direction = PacketDirection::ClientToServer;
         p[1].lookup_key.direction = PacketDirection::ServerToClient;
-        let mut parser = SofaRpcLog::new();
+        let mut parser = SofaRpcLog::default();
 
         let req_param = &mut ParseParam::from(&p[0]);
         let req_payload = p[0].get_l4_payload().unwrap();

--- a/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
+++ b/agent/src/flow_generator/protocol_logs/sql/postgresql.rs
@@ -173,12 +173,14 @@ pub struct PostgresqlLog {
 
 impl Default for PostgresqlLog {
     fn default() -> Self {
-        Self {
+        let mut log = Self {
             previous_log_info: LruCache::new(1),
             info: PostgreInfo::default(),
             perf_stats: None,
             parsed: false,
-        }
+        };
+        log.info.ignore = true;
+        log
     }
 }
 
@@ -290,12 +292,6 @@ impl L7FlowPerf for PostgresqlLog {
 }
 
 impl PostgresqlLog {
-    pub fn new() -> Self {
-        let mut s = Self::default();
-        s.info.ignore = true;
-        s
-    }
-
     fn set_msg_type(&mut self, direction: PacketDirection) {
         match direction {
             PacketDirection::ClientToServer => self.info.msg_type = LogMessageType::Request,
@@ -548,7 +544,7 @@ mod test {
         p[0].lookup_key.direction = PacketDirection::ClientToServer;
         p[1].lookup_key.direction = PacketDirection::ServerToClient;
 
-        let mut parser = PostgresqlLog::new();
+        let mut parser = PostgresqlLog::default();
         let req_param = &mut ParseParam::from(&p[0]);
         let req_payload = p[0].get_l4_payload().unwrap();
         assert_eq!((&mut parser).check_payload(req_payload, req_param), true);

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -73,3 +73,62 @@ pub use {
     policy::first_path::FirstPath as _FirstPath,
     policy::labeler::Labeler as _Labeler,
 };
+
+#[cfg(test)]
+mod tests {
+    macro_rules! print_size_of {
+        ($(($spaces: expr, $t: ty)),*) => {
+            $({
+                println!(concat!($spaces, stringify!($t), ": {}"), std::mem::size_of::<$t>());
+            })*
+        };
+    }
+
+    #[test]
+    fn struct_sizes() {
+        #[rustfmt::skip]
+        print_size_of![
+            ("", crate::flow_generator::flow_node::FlowNode),
+            ("    ", crate::common::TaggedFlow),
+            ("        ", crate::common::flow::Flow),
+            ("            ", crate::common::flow::FlowKey),
+            ("         2x ", crate::common::flow::FlowMetricsPeer),
+            ("            ", crate::common::flow::TunnelField),
+            ("            ", crate::common::flow::FlowPerfStats),
+            ("        ", crate::common::tag::Tag),
+            ("    ", crate::flow_generator::flow_state::FlowState),
+            (" -> ", crate::flow_generator::perf::FlowPerf),
+            ("        ", crate::flow_generator::perf::L4FlowPerfTable),
+            ("         +> ", crate::flow_generator::perf::tcp::TcpPerf),
+            ("         |      ", crate::flow_generator::perf::tcp::PerfControl),
+            ("         |       2x ", crate::flow_generator::perf::tcp::SessionPeer),
+            ("         |      ", crate::flow_generator::perf::tcp::PerfData),
+            ("         -- ", crate::flow_generator::perf::udp::UdpPerf),
+            ("     -> ", crate::flow_generator::perf::L7FlowPerfTable),
+            ("         +- ", crate::flow_generator::perf::dns::DnsPerfData),
+            ("         +- ", crate::flow_generator::perf::mq::KafkaPerfData),
+            ("         +- ", crate::flow_generator::perf::mq::MqttPerfData),
+            ("         +- ", crate::flow_generator::perf::sql::RedisPerfData),
+            ("         +- ", crate::flow_generator::perf::rpc::DubboPerfData),
+            ("         +- ", crate::flow_generator::perf::sql::MysqlPerfData),
+            ("         +- ", crate::flow_generator::perf::http::HttpPerfData),
+            ("         +> ", crate::flow_generator::protocol_logs::sql::PostgresqlLog),
+            ("         +> ", crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog),
+            ("         +> ", crate::flow_generator::protocol_logs::rpc::SofaRpcLog),
+            ("     -> ", crate::common::l7_protocol_log::L7ProtocolParser),
+            ("         +- ", crate::flow_generator::protocol_logs::http::HttpLog),
+            ("         +- ", crate::flow_generator::protocol_logs::dns::DnsLog),
+            ("         +- ", crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog),
+            ("         +- ", crate::flow_generator::protocol_logs::rpc::SofaRpcLog),
+            ("         +- ", crate::flow_generator::protocol_logs::sql::MysqlLog),
+            ("         +- ", crate::flow_generator::protocol_logs::mq::KafkaLog),
+            ("         +- ", crate::flow_generator::protocol_logs::sql::RedisLog),
+            ("         +- ", crate::flow_generator::protocol_logs::sql::PostgresqlLog),
+            ("         +- ", crate::flow_generator::protocol_logs::rpc::DubboLog),
+            ("         +- ", crate::flow_generator::protocol_logs::mq::MqttLog),
+            (" 2x ", npb_pcap_policy::PolicyData),
+            (" 2x ", crate::common::endpoint::EndpointData),
+            (" -> ", packet_sequence_block::PacketSequenceBlock)
+        ];
+    }
+}

--- a/agent/src/lib.rs
+++ b/agent/src/lib.rs
@@ -94,7 +94,7 @@ mod tests {
             ("            ", crate::common::flow::FlowKey),
             ("         2x ", crate::common::flow::FlowMetricsPeer),
             ("            ", crate::common::flow::TunnelField),
-            ("            ", crate::common::flow::FlowPerfStats),
+            ("         -> ", crate::common::flow::FlowPerfStats),
             ("        ", crate::common::tag::Tag),
             ("    ", crate::flow_generator::flow_state::FlowState),
             (" -> ", crate::flow_generator::perf::FlowPerf),


### PR DESCRIPTION
<!--

Thank you for contributing to DeepFlow!
Please read this template before submitting pull requests.
Texts surrounded by `<` and `>` should be replaced accordingly.
Put an `x` in `[ ]` to mark the item as checked. `[x]`

-->

### This PR is for:
- Agent

<!-- ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ====
### Fixes <bug description, issue number or issue link>
#### Steps to reproduce the bug
- <steps here>
- ...
#### Changes to fix the bug
- <changes here>
- ...
#### Affected branches
- main
#### Checklist
- [ ] Added unit test to verify the fix.
     ==== Remove this line WHEN AND ONLY WHEN you're fixing a bug, follow the checklist ==== -->

<!-- ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ====
### Improves the performance of <crate, module, class or any description>
#### Added benchmark
- <link here>
#### Benchmark result
```text
<Paste benchmark results>
````
     ==== Remove this line WHEN AND ONLY WHEN you're improving the performance, follow the checklist ==== -->

### Fix unit tests
### Reduce memory consumption for Option fields

indentation means fields in struct
`->` means boxed
`2x` means two instances
`+-`  means types in enum
`+>`  means boxed types in enum

#### Before
```
crate::flow_generator::flow_node::FlowNode: 2328
    crate::common::TaggedFlow: 696
        crate::common::flow::Flow: 632
            crate::common::flow::FlowKey: 72
         2x crate::common::flow::FlowMetricsPeer: 120
            crate::common::flow::TunnelField: 44
            crate::common::flow::FlowPerfStats: 144
        crate::common::tag::Tag: 64
    crate::flow_generator::flow_state::FlowState: 1
    crate::flow_generator::perf::FlowPerf: 1472
        crate::flow_generator::perf::L4FlowPerfTable: 752
         -- crate::flow_generator::perf::tcp::TcpPerf: 752
         |      crate::flow_generator::perf::tcp::PerfControl: 384
         |       2x crate::flow_generator::perf::tcp::SessionPeer: 192
         |      crate::flow_generator::perf::tcp::PerfData: 352
         -- crate::flow_generator::perf::udp::UdpPerf: 56
        crate::flow_generator::perf::L7FlowPerfTable: 344
         +- crate::flow_generator::perf::dns::DnsPerfData: 96
         +- crate::flow_generator::perf::mq::KafkaPerfData: 104
         +- crate::flow_generator::perf::mq::MqttPerfData: 96
         +- crate::flow_generator::perf::sql::RedisPerfData: 96
         +- crate::flow_generator::perf::rpc::DubboPerfData: 112
         +- crate::flow_generator::perf::sql::MysqlPerfData: 104
         +- crate::flow_generator::perf::http::HttpPerfData: 112
         +- crate::flow_generator::protocol_logs::sql::PostgresqlLog: 288
         +- crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog: 288
         +- crate::flow_generator::protocol_logs::rpc::SofaRpcLog: 336
        crate::common::l7_protocol_log::L7ProtocolParser: 344
         +- crate::flow_generator::protocol_logs::http::HttpLog: 320
         +- crate::flow_generator::protocol_logs::dns::DnsLog: 88
         +- crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog: 288
         +- crate::flow_generator::protocol_logs::rpc::SofaRpcLog: 336
         +- crate::flow_generator::protocol_logs::sql::MysqlLog: 128
         +- crate::flow_generator::protocol_logs::mq::KafkaLog: 96
         +- crate::flow_generator::protocol_logs::sql::RedisLog: 160
         +- crate::flow_generator::protocol_logs::sql::PostgresqlLog: 288
         +- crate::flow_generator::protocol_logs::rpc::DubboLog: 200
         +- crate::flow_generator::protocol_logs::mq::MqttLog: 96
 2x npb_pcap_policy::PolicyData: 32
 2x crate::common::endpoint::EndpointData: 64
    packet_sequence_block::PacketSequenceBlock: 0
```

#### After
```
crate::flow_generator::flow_node::FlowNode: 664
    crate::common::TaggedFlow: 496
        crate::common::flow::Flow: 432
            crate::common::flow::FlowKey: 72
         2x crate::common::flow::FlowMetricsPeer: 104
            crate::common::flow::TunnelField: 44
         -> crate::common::flow::FlowPerfStats: 144
        crate::common::tag::Tag: 64
    crate::flow_generator::flow_state::FlowState: 1
 -> crate::flow_generator::perf::FlowPerf: 80
        crate::flow_generator::perf::L4FlowPerfTable: 32
         +> crate::flow_generator::perf::tcp::TcpPerf: 600
         |      crate::flow_generator::perf::tcp::PerfControl: 352
         |       2x crate::flow_generator::perf::tcp::SessionPeer: 176
         |      crate::flow_generator::perf::tcp::PerfData: 232
         -- crate::flow_generator::perf::udp::UdpPerf: 32
     -> crate::flow_generator::perf::L7FlowPerfTable: 120
         +- crate::flow_generator::perf::dns::DnsPerfData: 96
         +- crate::flow_generator::perf::mq::KafkaPerfData: 104
         +- crate::flow_generator::perf::mq::MqttPerfData: 96
         +- crate::flow_generator::perf::sql::RedisPerfData: 96
         +- crate::flow_generator::perf::rpc::DubboPerfData: 112
         +- crate::flow_generator::perf::sql::MysqlPerfData: 104
         +- crate::flow_generator::perf::http::HttpPerfData: 112
         +> crate::flow_generator::protocol_logs::sql::PostgresqlLog: 288
         +> crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog: 288
         +> crate::flow_generator::protocol_logs::rpc::SofaRpcLog: 336
     -> crate::common::l7_protocol_log::L7ProtocolParser: 128
         +- crate::flow_generator::protocol_logs::http::HttpLog: 320
         +- crate::flow_generator::protocol_logs::dns::DnsLog: 88
         +- crate::flow_generator::protocol_logs::rpc::ProtobufRpcWrapLog: 288
         +- crate::flow_generator::protocol_logs::rpc::SofaRpcLog: 336
         +- crate::flow_generator::protocol_logs::sql::MysqlLog: 128
         +- crate::flow_generator::protocol_logs::mq::KafkaLog: 96
         +- crate::flow_generator::protocol_logs::sql::RedisLog: 160
         +- crate::flow_generator::protocol_logs::sql::PostgresqlLog: 288
         +- crate::flow_generator::protocol_logs::rpc::DubboLog: 200
         +- crate::flow_generator::protocol_logs::mq::MqttLog: 96
 2x npb_pcap_policy::PolicyData: 32
 2x crate::common::endpoint::EndpointData: 64
 -> packet_sequence_block::PacketSequenceBlock: 0
```

<!-- ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ====
### <Description of the change>
     ==== Remove this line WHEN AND ONLY WHEN you're updating document or workflow, follow the checklist ==== -->

<!-- Uncomment if the PR fixes an issue
Fixes #(issue-number)
-->

