### PR TITLE
[Agent] fix guard cgroup check

### DIFF
--- a/agent/crates/public/src/consts.rs
+++ b/agent/crates/public/src/consts.rs
@@ -33,6 +33,10 @@ pub const DEFAULT_CPU_CFS_PERIOD_US: u32 = 100000; // cfs_period_us默认值
 
 pub const DEFAULT_LOG_RETENTION: u32 = 365;
 pub const DEFAULT_LOG_FILE_SIZE_LIMIT: u32 = 10000; // 单位：M
+pub const CGROUP_PROCS_PATH: &'static str = "cpu/deepflow-agent/cgroup.procs";
+pub const CGROUP_TASKS_PATH: &'static str = "cpu/deepflow-agent/tasks";
+pub const CGROUP_V2_PROCS_PATH: &'static str = "deepflow-agent/cgroup.procs";
+pub const CGROUP_V2_THREADS_PATH: &'static str = "deepflow-agent/cgroup.threads";
 
 #[cfg(target_os = "linux")]
 mod platform_consts {
@@ -41,10 +45,6 @@ mod platform_consts {
     pub const COREFILE_FORMAT: &'static str = "core";
     pub const DEFAULT_COREFILE_PATH: &'static str = "/tmp";
     pub const DEFAULT_LIBVIRT_XML_PATH: &'static str = "/etc/libvirt/qemu";
-    pub const CGROUP_PROCS_PATH: &'static str = "/sys/fs/cgroup/cpu/deepflow-agent/cgroup.procs";
-    pub const CGROUP_TASKS_PATH: &'static str = "/sys/fs/cgroup/cpu/deepflow-agent/tasks";
-    pub const CGROUP_V2_PROCS_PATH: &'static str = "/sys/fs/cgroup/deepflow-agent/cgroup.procs";
-    pub const CGROUP_V2_THREADS_PATH: &'static str = "/sys/fs/cgroup/deepflow-agent/cgroup.threads";
 }
 
 #[cfg(target_os = "windows")]

--- a/agent/src/config/handler.rs
+++ b/agent/src/config/handler.rs
@@ -38,6 +38,7 @@ use super::{
 };
 use crate::common::l7_protocol_log::L7ProtocolBitmap;
 use crate::flow_generator::protocol_logs::SOFA_NEW_RPC_TRACE_CTX_KEY;
+use crate::utils::environment::free_memory_check;
 use crate::{
     common::{decapsulate::TunnelTypeBitmap, enums::TapType},
     dispatcher::recv_engine,
@@ -46,7 +47,8 @@ use crate::{
     handler::PacketHandlerBuilder,
     trident::{Components, RunningMode},
     utils::{
-        environment::{free_memory_check, get_ctrl_ip_and_mac, running_in_container},
+        cgroups::is_kernel_available_for_cgroup,
+        environment::{get_ctrl_ip_and_mac, running_in_container},
         logger::RemoteLogConfig,
     },
 };
@@ -1120,7 +1122,11 @@ impl ConfigHandler {
             candidate_config.tap_mode = new_config.tap_mode;
         }
 
-        if candidate_config.tap_mode != TapMode::Analyzer && !running_in_container() {
+        if candidate_config.tap_mode != TapMode::Analyzer
+            && !running_in_container()
+            && !is_kernel_available_for_cgroup()
+        // In the environment where cgroup is not supported, we need to check free memory
+        {
             // Check and send out exceptions in time
             if let Err(e) = free_memory_check(new_config.environment.max_memory, exception_handler)
             {
@@ -1233,8 +1239,10 @@ impl ConfigHandler {
                                 }
                             }
                             _ => {
-                                if !running_in_container() {
+                                if !running_in_container() && !is_kernel_available_for_cgroup() {
+                                    // In the environment where cgroup is not supported, we need to check free memory
                                     match free_memory_check(
+                                        // fixme: It can skip this check because it has been checked before
                                         handler.candidate_config.environment.max_memory,
                                         &components.exception_handler,
                                     ) {
@@ -1820,9 +1828,13 @@ impl ConfigHandler {
                 for dispatcher in components.dispatchers.iter() {
                     dispatcher.stop();
                 }
-                if handler.candidate_config.tap_mode != TapMode::Analyzer && !running_in_container()
+                if handler.candidate_config.tap_mode != TapMode::Analyzer
+                    && !running_in_container()
+                    && !is_kernel_available_for_cgroup()
+                // In the environment where cgroup is not supported, we need to check free memory
                 {
                     match free_memory_check(
+                        // fixme: It can skip this check because it has been checked before
                         handler.candidate_config.environment.max_memory,
                         &components.exception_handler,
                     ) {

--- a/agent/src/utils/cgroups/mod.rs
+++ b/agent/src/utils/cgroups/mod.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use thiserror::Error;
+
+#[cfg(target_os = "linux")]
+mod linux;
+#[cfg(target_os = "linux")]
+pub use linux::*;
+#[cfg(target_os = "windows")]
+mod windows;
+#[cfg(target_os = "windows")]
+pub use self::windows::*;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error("cgroup is not supported: {0}")]
+    CgroupNotSupported(String),
+    #[error("set cpu controller failed: {0}")]
+    CpuControllerSetFailed(String),
+    #[error("set mem controller failed: {0}")]
+    MemControllerSetFailed(String),
+    #[error("apply resources failed: {0}")]
+    ApplyResourcesFailed(String),
+    #[error("delete cgroup failed: {0}")]
+    DeleteCgroupFailed(String),
+}

--- a/agent/src/utils/cgroups/windows.rs
+++ b/agent/src/utils/cgroups/windows.rs
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022 Yunshan Networks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::time::Duration;
+use std::{process, thread};
+
+use super::Error;
+use crate::config::handler::EnvironmentAccess;
+
+use log::{info, warn};
+
+pub struct Cgroups {}
+
+impl Cgroups {
+    pub fn new(_pid: u64, _config: EnvironmentAccess) -> Result<Self, Error> {
+        Err(Error::CgroupNotSupported(
+            "Windows agent's cgroup is not supported".to_string(),
+        ))
+    }
+    pub fn start(&self) {}
+    pub fn get_mount_path(&self) -> String {
+        String::default()
+    }
+    pub fn is_v2(&self) -> bool {
+        false
+    }
+    pub fn stop(&self) -> Result<(), Error> {
+        Err(Error::CgroupNotSupported(
+            "Windows agent's cgroup is not supported".to_string(),
+        ))
+    }
+}
+
+pub fn is_kernel_available_for_cgroup() -> bool {
+    false
+}

--- a/agent/src/utils/environment.rs
+++ b/agent/src/utils/environment.rs
@@ -56,7 +56,9 @@ use crate::error::{Error, Result};
 use crate::exception::ExceptionHandler;
 use public::proto::{common::TridentType, trident::Exception};
 
-use super::process::{get_memory_rss, get_process_num_by_name};
+#[cfg(target_os = "windows")]
+use super::process::get_memory_rss;
+use super::process::get_process_num_by_name;
 #[cfg(target_os = "linux")]
 use public::utils::net::get_link_enabled_features;
 use public::utils::net::{get_mac_by_ip, get_route_src_ip_and_mac, link_by_name, MacAddr};
@@ -139,6 +141,12 @@ pub fn tap_interface_check(tap_interfaces: &[String]) {
     }
 }
 
+#[cfg(target_os = "linux")]
+pub fn free_memory_check(_required: u64, _exception_handler: &ExceptionHandler) -> Result<()> {
+    return Ok(()); // fixme: The way to obtain free memory is different in earlier versions of Linux, which requires adaptation
+}
+
+#[cfg(target_os = "windows")]
 pub fn free_memory_check(required: u64, exception_handler: &ExceptionHandler) -> Result<()> {
     get_memory_rss()
         .map_err(|e| Error::Environment(e.to_string()))

--- a/agent/src/utils/mod.rs
+++ b/agent/src/utils/mod.rs
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-#[cfg(target_os = "linux")]
 pub(crate) mod cgroups;
 pub(crate) mod command;
 pub(crate) mod environment;


### PR DESCRIPTION
### This PR is for:

- Agent

### Fixes guard cgroup check
#### Steps to reproduce the bug
- Modify the default mount directory of cgroup. The cgroup check in guard will cause the agent to restart
#### Changes to fix the bug
- Get the mount directory of cgroup and check the procs file and tasks file under the path instead of checking the fixed file path
- When the kernel version is too low, do not set cgroup and only print the warning log
- Optimize free memory check
#### Affected branches
- main
- v6.1
#### Checklist
- [ ] Added unit test to verify the fix.
     