### PR TITLE
[eBPF] Fix datadump error caused by only-stdout #20159

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -857,8 +857,10 @@ static void process_events_handle_main(__unused void *arg)
 				fprintf(datadump_file,
 					"\n\nDump data is finished, use time: %us.\n\n",
 					datadump_timeout);
-				ebpf_info("close datadump file %s\n", datadump_file_path);
-				fclose(datadump_file);
+				if (datadump_file != stdout) {
+					ebpf_info("close datadump file %s\n", datadump_file_path);
+					fclose(datadump_file);
+				}
 				memcpy(datadump_file_path, "stdout", 7);
 				datadump_file = stdout;
 				datadump_timeout = 0;


### PR DESCRIPTION
Fix datadump error caused by only-stdout 

### This PR is for:


- Agent



#### Affected branches
- main
- v6.1

- [ ] Added unit test.

