### PR TITLE
[eBPF] Fixed datadump cannot be shut down after timeout 

### DIFF
--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -375,12 +375,6 @@ static int datadump_sockopt_set(sockoptid_t opt, const void *conf, size_t size)
 			  datadump_comm,
 			  datadump_proto);
 	} else {
-		if (datadump_enable && !msg->enable) {
-			// close output file
-			if (datadump_file != stdout)
-				fclose(datadump_file);
-		}
-
 		if (!datadump_enable && msg->enable) {
 			// create a new output file
 			if (datadump_file == stdout && !msg->only_stdout) {
@@ -408,18 +402,23 @@ static int datadump_sockopt_set(sockoptid_t opt, const void *conf, size_t size)
 			datadump_timeout = msg->timeout;
 		}
 
-		datadump_enable = msg->enable;
-		if (!datadump_enable) {
+		if (datadump_enable && !msg->enable) {
 			datadump_timeout = 0;
 			datadump_pid = 0;
 			datadump_comm[0] = '\0';
 			datadump_proto = 0;
+			fprintf(datadump_file, "\n\nDump data is finished, use time: %us.\n\n",
+				get_sys_uptime() - datadump_start_time);
+			if (datadump_file != stdout) {
+				fclose(datadump_file);
+				ebpf_info("close datadump file %s\n", datadump_file_path);
+			}
 			memcpy(datadump_file_path, "stdout", 7);
 			datadump_file = stdout;
-			fprintf(datadump_file, "\nDump data is finished, use time: %us.\n",
-				get_sys_uptime() - datadump_start_time);
 			datadump_start_time = 0;
 		}
+
+		datadump_enable = msg->enable;
 		ebpf_info("datadump %s\n", datadump_enable ? "enable" : "disable");
 	}
 	pthread_mutex_unlock(&datadump_mutex);
@@ -841,6 +840,34 @@ static int check_kern_adapt_and_state_update(void)
 	return 0;
 }
 
+static void check_datadump_timeout(void)
+{
+	uint32_t passed_sec;
+	pthread_mutex_lock(&datadump_mutex);
+	if (datadump_enable) {
+		passed_sec = get_sys_uptime() - datadump_start_time;
+		if (passed_sec > datadump_timeout) {
+			datadump_start_time = 0;
+			datadump_enable = false;
+			datadump_pid = 0;
+			datadump_comm[0] = '\0';
+			datadump_proto = 0;
+			fprintf(datadump_file,
+				"\n\nDump data is finished, use time: %us.\n\n",
+				datadump_timeout);
+			if (datadump_file != stdout) {
+				ebpf_info("close datadump file %s\n", datadump_file_path);
+				fclose(datadump_file);
+			}
+			memcpy(datadump_file_path, "stdout", 7);
+			datadump_file = stdout;
+			datadump_timeout = 0;
+			ebpf_info("datadump disable\n");
+		}
+	}
+	pthread_mutex_unlock(&datadump_mutex);	
+}
+
 // Manage process start or exit events.
 static void process_events_handle_main(__unused void *arg)
 {
@@ -848,6 +875,7 @@ static void process_events_handle_main(__unused void *arg)
 	for(;;) {
 		go_process_events_handle();
 		ssl_events_handle();
+		check_datadump_timeout();
 		usleep(LOOP_DELAY_US);
 	}
 }
@@ -1925,21 +1953,6 @@ static void print_socket_data(struct socket_bpf_data *sd)
 #define OUTPUT_DATA_SIZE 128
 
 	bool output = false;
-	uint32_t passed_sec = get_sys_uptime() - datadump_start_time;
-	if (passed_sec > datadump_timeout) {
-		datadump_start_time = 0;
-		datadump_enable = false;
-		datadump_timeout = 0;
-		datadump_pid = 0;
-		datadump_comm[0] = '\0';
-		datadump_proto = 0;
-		memcpy(datadump_file_path, "stdout", 7);
-		datadump_file = stdout;
-		fprintf(datadump_file, "\nDump data is finished, use time: %us.\n",
-			datadump_timeout);
-		return;
-	}
-
 	if (datadump_pid == 0 && (strlen(datadump_comm) > 0)
 	    && (datadump_proto == 0)) {
 		if (strcmp((char *)sd->process_kname, (char *)datadump_comm) ==


### PR DESCRIPTION
Previously we checked whether the datadump timedout by triggering eBPF-data.
This was not a good idea, if no eBPF-data arrived, the datadump would remain open.

After the adjustment, the datadump can be closed in another thread by checking the timeout.

### This PR is for:


- Agent




#### Affected branches
- main

#### Checklist
- [ ] Added unit test.
