### PR TITLE
[eBPF] Fix tracer can't work due to too many uprobes

### DIFF
--- a/agent/src/ebpf/mod.rs
+++ b/agent/src/ebpf/mod.rs
@@ -87,6 +87,14 @@ pub const TRACER_INIT: u8 = 0;
 pub const TRACER_RUNNING: u8 = 1;
 #[allow(dead_code)]
 pub const TRACER_STOP: u8 = 2;
+#[allow(dead_code)]
+pub const TRACER_WAIT_START: u8 = 3;
+#[allow(dead_code)]
+pub const TRACER_START_ERR: u8 = 4;
+#[allow(dead_code)]
+pub const TRACER_WAIT_STOP: u8 = 5;
+#[allow(dead_code)]
+pub const TRACER_STOP_ERR: u8 = 6;
 
 // 消息类型
 // 目前除了 source=EBPF_TYPE_GO_HTTP2_UPROBE 以外,都不能保证这个方向的正确性.
@@ -301,7 +309,8 @@ pub struct SK_TRACE_STATS {
      * tracer 当前状态
      */
     pub is_adapt_success: bool, // 适配状态：内核适配成功为true，否则为false
-    pub tracer_state: u8,       // 追踪器当前状态。值：TRACER_INIT, TRACER_STOP，TRACER_RUNNING
+    pub tracer_state: u8,       // 追踪器当前状态。值：TRACER_INIT, TRACER_STOP，TRACER_RUNNING,
+    // TRACER_WAIT_START, TRACER_START_ERR, TRACER_WAIT_STOP, TRACER_STOP_ERR
 
     /*
      * 纳秒级系统启动时间每分钟进行一次更新，

--- a/agent/src/ebpf/user/common.c
+++ b/agent/src/ebpf/user/common.c
@@ -429,7 +429,7 @@ int fetch_kernel_version(int *major, int *minor, int *patch)
 	return ETR_OK;
 }
 
-int fetch_system_type(char *sys_type, int type_len)
+int fetch_system_type(const char *sys_type, int type_len)
 {
 	int len, i, count = 0;
 	char *p = NULL;
@@ -452,9 +452,19 @@ int fetch_system_type(char *sys_type, int type_len)
 		return ETR_INVAL;
 
 	len = strlen(p) + 1 > type_len ? type_len : strlen(p) + 1;
-	memcpy(sys_type, p, len);
+	memcpy((void *)sys_type, p, len);
 
 	return ETR_OK;
+}
+
+void fetch_linux_release(const char *buf, int buf_len)
+{
+	struct utsname sys_info;
+	uname(&sys_info);
+	int len =
+	    strlen(sys_info.release) + 1 >
+	    buf_len ? buf_len : strlen(sys_info.release) + 1;
+	memcpy((void *)buf, sys_info.release, len);
 }
 
 unsigned int fetch_kernel_version_code(void)

--- a/agent/src/ebpf/user/common.h
+++ b/agent/src/ebpf/user/common.h
@@ -266,5 +266,6 @@ int get_num_possible_cpus(void);
 bool is_process(int pid);
 char *gen_file_name_by_datetime(void);
 char *gen_timestamp_prefix(void);
-int fetch_system_type(char *sys_type, int type_len);
+int fetch_system_type(const char *sys_type, int type_len);
+void fetch_linux_release(const char *buf, int buf_len);
 #endif /* DF_COMMON_H */

--- a/agent/src/ebpf/user/ctrl_tracer.c
+++ b/agent/src/ebpf/user/ctrl_tracer.c
@@ -121,8 +121,7 @@ static void tracer_dump(struct bpf_tracer_param *param)
 	printf("%-18s %d\n", "Perf-Pages-Count", btp->perf_pg_cnt);
 	printf("%-18s %" PRIu64 "\n", "Events Lost", btp->lost);
 	printf("%-18s %d\n", "Probes Count", btp->probes_count);
-	printf("%-18s %d [ 0 (TRACER_INIT), 1 (TRACER_RUNNING), "
-	       "2 (TRACER_STOP) ]\n", "State", btp->state);
+	printf("%-18s %s\n", "State", get_tracer_state_name(btp->state));
 	printf("%-18s %d\n", "Adapt", btp->adapt_success);
 	printf("%-18s %d\n", "data_limit_max", btp->data_limit_max);
 	printf("\n-------------------- Queue ---------------------------\n");
@@ -458,9 +457,8 @@ static int socktrace_do_cmd(struct df_bpf_obj *obj, df_bpf_cmd_t cmd,
 		printf("datadump_file_path:\t%s\n\n",
 		       sk_trace_params->datadump_file_path);
 
-		printf
-		    ("tracer_state:\t%u [ 0 (TRACER_INIT), 1 (TRACER_RUNNING), "
-		     "2 (TRACER_STOP) ]\n\n", sk_trace_params->tracer_state);
+		printf("tracer_state:\t%s\n\n",
+		       get_tracer_state_name(sk_trace_params->tracer_state));
 
 		for (i = 0; i < array->count; i++) {
 			if (array->offsets[i].ready != 1)

--- a/agent/src/ebpf/user/go_tracer.c
+++ b/agent/src/ebpf/user/go_tracer.c
@@ -978,7 +978,12 @@ void go_process_events_handle(void)
 			pthread_mutex_unlock(&mutex_proc_events_lock);
 
 			if (pe->type == EVENT_TYPE_PROC_EXEC) {
-				if (access(pe->path, F_OK) == 0) {
+				/*
+				 * Threads and processes share the code section,
+				 * here only processes are concerned.
+				 */
+				if (is_process(pe->pid)
+				    && access(pe->path, F_OK) == 0) {
 					process_execute_handle(pe->pid,
 							       pe->tracer);
 				}

--- a/agent/src/ebpf/user/socket.c
+++ b/agent/src/ebpf/user/socket.c
@@ -40,8 +40,20 @@ static uint64_t socket_map_reclaim_count;	// socket map回收数量统计
 static uint64_t trace_map_reclaim_count;	// trace map回收数量统计
 
 static struct list_head events_list;	// Use for extra register events
-
 static pthread_t proc_events_pthread;	// Process exec/exit thread
+
+/*
+ * tracer_hooks_detach() and tracer_hooks_attach() will become terrible
+ * when the number of probes is very large. Because we have to spend a
+ * long time waiting for it to complete, this is not a good way, we hope
+ * that calling socket_tracer_stop() or socket_tracer_start() will not
+ * block the execution of subsequent tasks.
+ *
+ * In order to solve this problem, we use a global variable(`probes_act`)
+ * to hold the latest attach/detach behavior, it be executed later by
+ * another thread, so that the current thread will not be blocked.
+ */
+static volatile uint64_t probes_act;
 
 extern int sys_cpus_count;
 extern bool *cpu_online;
@@ -75,6 +87,7 @@ static uint32_t go_tracing_timeout = GO_TRACING_TIMEOUT_DEFAULT;
 static uint32_t conf_socket_map_max_reclaim;
 
 extern int major, minor;
+extern char linux_release[128];
 
 extern uint64_t sys_boot_time_ns;
 extern uint64_t prev_sys_boot_time_ns;
@@ -821,6 +834,11 @@ static int check_map_exceeded(void)
 	return 0;
 }
 
+static inline void add_probes_act(enum probes_act_type type)
+{
+	probes_act = type;	
+}
+
 static int check_kern_adapt_and_state_update(void)
 {
 	struct bpf_tracer *t = find_bpf_tracer(SK_TRACER_NAME);
@@ -828,16 +846,62 @@ static int check_kern_adapt_and_state_update(void)
 		return -1;
 
 	if (is_adapt_success(t)) {
-		ebpf_info("Linux %d.%d adapt success.\n", major, minor);
-		if (tracer_hooks_detach(t) == 0) {
-			t->state = TRACER_STOP;
-			ebpf_info("Set current state: TRACER_STOP.\n");
-		}
+		ebpf_info("Linux %s adapt success. Set the status to TRACER_RUNNING\n",
+			  linux_release);
+		t->state = TRACER_RUNNING;
+		add_probes_act(ACT_DETACH);
 		set_period_event_invalid("check-kern-adapt");
 		t->adapt_success = true;
 	}
 
 	return 0;
+}
+
+static void process_probes_act(struct bpf_tracer *t)
+{
+	if (probes_act == ACT_NONE)
+		return;
+	enum probes_act_type type = probes_act;
+
+        /*
+         * Probes attach/detach in multithreading, e.g.:
+         * 1. Snoop go process execute/exit events, then process events(add/remove probes).
+         * 2. Start/stop tracer need process probes.
+         * The above scenario is handled in different threads, so use thread locks for protection.
+         */
+	pthread_mutex_lock(&t->mutex_probes_lock);
+	// If there is an unfinished attach/detach, return directly.
+	if (t->state == TRACER_WAIT_STOP || t->state == TRACER_WAIT_START) {
+		ebpf_warning("Current state: %s. There are unfinished tasks.\n",
+			     get_tracer_state_name(t->state));
+		pthread_mutex_unlock(&t->mutex_probes_lock);
+		return;
+	}
+
+	if (type == ACT_DETACH && t->state == TRACER_RUNNING) {
+		t->state = TRACER_WAIT_STOP;
+		ebpf_info("Set current state: TRACER_WAIT_STOP.\n");
+		if (tracer_hooks_detach(t) == 0) {
+			t->state = TRACER_STOP;
+			ebpf_info("Set current state: TRACER_STOP.\n");
+		} else {
+			t->state = TRACER_STOP_ERR;
+			ebpf_warning("Set current state: TRACER_STOP_ERR.\n");
+		}
+		// clean socket map
+		reclaim_socket_map(t, 0);
+	} else if (type == ACT_ATTACH && t->state == TRACER_STOP) {
+		t->state = TRACER_WAIT_START;
+		ebpf_info("Set current state: TRACER_WAIT_START.\n");
+		if (tracer_hooks_attach(t) == 0) {
+			t->state = TRACER_RUNNING;
+			ebpf_info("Set current state: TRACER_RUNNING.\n");
+		} else {
+			t->state = TRACER_START_ERR;
+			ebpf_warning("Set current state: TRACER_START_ERR.\n");
+		}
+	}
+	pthread_mutex_unlock(&t->mutex_probes_lock);
 }
 
 static void check_datadump_timeout(void)
@@ -872,7 +936,22 @@ static void check_datadump_timeout(void)
 static void process_events_handle_main(__unused void *arg)
 {
 	prctl(PR_SET_NAME, "proc-events");
+	struct bpf_tracer *t = arg;
 	for(;;) {
+		/*
+		 * Will attach/detach all probes in the following cases:
+		 *
+		 * 1 The socket tracer startup phase will transition from TRACER_INIT to TRACER_STOP.
+		 * 2 states from TRACER_STOP to TRACER_RUNNIN.
+		 * 3 state from TRACER_RUNNING to TRACER_STOP.
+		 *
+		 * The behavior of attach/detach will take a lot of time, we will store it into
+		 * `probes_act` for asynchronous processing.
+		 *
+		 * Here, handle attach/detach behavior.
+		 */
+		process_probes_act(t);
+
 		go_process_events_handle();
 		ssl_events_handle();
 		check_datadump_timeout();
@@ -1215,6 +1294,7 @@ int running_socket_tracer(l7_handle_fn handle,
 		return -EINVAL;
 
 	tracer->state = TRACER_INIT;
+	probes_act = ACT_NONE;
 	tracer->adapt_success = false;
 
 	/*
@@ -1331,7 +1411,7 @@ int running_socket_tracer(l7_handle_fn handle,
 		return ret;
 	ret =
 	    pthread_create(&proc_events_pthread, NULL,
-			   (void *)&process_events_handle_main, NULL);
+			   (void *)&process_events_handle_main, (void *)tracer);
 	if (ret) {
 		ebpf_info
 		    ("<%s> proc_events_pthread, pthread_create is error:%s\n",
@@ -1348,35 +1428,23 @@ static int socket_tracer_stop(void)
 	struct bpf_tracer *t = find_bpf_tracer(SK_TRACER_NAME);
 	if (t == NULL)
 		return ret;
-
 	if (t->state == TRACER_INIT) {
 		ebpf_warning
-		    ("socket_tracer state is TRACER_INIT, not permit stop.\n");
+		    ("Adapting the linux kernel(%s) is in progress, please try "
+		     "the stop operation again later.\n", linux_release);
 		return -1;
 	}
 
-	if (t->state == TRACER_STOP) {
+	if (probes_act == ACT_DETACH) {
 		ebpf_warning
-		    ("socket_tracer state is already TRACER_STOP, without operating.\n");
+		    ("The latest probes_act is already ACT_DETACH, without operating.\n");
+			
 		return 0;
 	}
 
-	/*
-	 * Probes attach/detach in multithreading, e.g.:
-	 * 1. Snoop go process execute/exit events, then process events(add/remove probes).
-	 * 2. Start/stop tracer need process probes. 
-	 * The above scenario is handled in different threads, so use thread locks for protection.
-	 */
-	pthread_mutex_lock(&t->mutex_probes_lock);
-	if ((ret = tracer_hooks_detach(t)) == 0) {
-		t->state = TRACER_STOP;
-		ebpf_info("Tracer stop success, current state: TRACER_STOP\n");
-	}
-	//清空 ebpf map
-	reclaim_socket_map(t, 0);
-	pthread_mutex_unlock(&t->mutex_probes_lock);
-
-	return ret;
+	ebpf_info("Call socket_tracer_stop()\n");
+	add_probes_act(ACT_DETACH);
+	return 0;
 }
 
 static int socket_tracer_start(void)
@@ -1387,26 +1455,22 @@ static int socket_tracer_start(void)
 		return ret;
 
 	if (t->state == TRACER_INIT) {
-		ebpf_info
-		    ("socket_tracer state is TRACER_INIT, not permit start.\n");
+		ebpf_warning
+		    ("Adapting the linux kernel(%s) is in progress, please try "
+		     "the start operation again later.\n", linux_release);
 		return -1;
 	}
 
-	if (t->state == TRACER_RUNNING) {
+	if (probes_act == ACT_ATTACH) {
 		ebpf_warning
-		    ("socket_tracer state is already TRACER_RUNNING, without operating.\n");
+		    ("The latest probes_act already ACT_ATTACH, without operating.\n");
 		return 0;
 	}
-	// Protect the probes operation in multiple threads, similar to socket_tracer_stop()
-	pthread_mutex_lock(&t->mutex_probes_lock);
-	if ((ret = tracer_hooks_attach(t)) == 0) {
-		t->state = TRACER_RUNNING;
-		ebpf_info
-		    ("Tracer start success, current state: TRACER_RUNNING\n");
-	}
-	pthread_mutex_unlock(&t->mutex_probes_lock);
 
-	return ret;
+	ebpf_info("Call socket_tracer_start()\n");
+	add_probes_act(ACT_ATTACH);
+
+	return 0;
 }
 
 static bool bpf_stats_map_collect(struct bpf_tracer *tracer,

--- a/agent/src/ebpf/user/socket.h
+++ b/agent/src/ebpf/user/socket.h
@@ -25,6 +25,12 @@
 #define CACHE_LINE_ROUNDUP(size) \
   (CACHE_LINE_SIZE * ((size + CACHE_LINE_SIZE - 1) / CACHE_LINE_SIZE))
 
+enum probes_act_type {
+	ACT_NONE,
+	ACT_ATTACH,
+	ACT_DETACH
+};
+
 struct socket_bpf_data {
 	/* session info */
 	uint32_t process_id;	   // tgid in kernel struct task_struct
@@ -193,6 +199,20 @@ static inline char *get_proto_name(uint16_t proto_id)
 	}
 
 	return "Unknown";
+}
+
+static inline const char *get_tracer_state_name(enum tracer_state s)
+{
+	switch(s) {
+	case TRACER_INIT: return "TRACER_INIT";
+	case TRACER_RUNNING: return "TRACER_RUNNING";
+	case TRACER_STOP: return "TRACER_STOP";
+	case TRACER_WAIT_START: return "TRACER_WAIT_START";
+	case TRACER_START_ERR: return "TRACER_START_ERR";
+	case TRACER_WAIT_STOP: return "TRACER_WAIT_STOP";
+	case TRACER_STOP_ERR: return "TRACER_STOP_ERR";
+	default: return "TRACER_UNKNOWN";
+	}
 }
 
 int set_data_limit_max(int limit_size);

--- a/agent/src/ebpf/user/tracer.h
+++ b/agent/src/ebpf/user/tracer.h
@@ -82,7 +82,11 @@ enum tracer_hook_type {
 enum tracer_state {
 	TRACER_INIT,
 	TRACER_RUNNING,
-	TRACER_STOP
+	TRACER_STOP,
+	TRACER_WAIT_START,
+	TRACER_START_ERR,
+	TRACER_WAIT_STOP,
+	TRACER_STOP_ERR
 };
 
 enum probe_type {
@@ -334,9 +338,9 @@ struct bpf_tracer {
 	 */
 	tracer_ctl_fun_t stop_handle;
 	tracer_ctl_fun_t start_handle;
-	enum tracer_state state;	// 追踪器状态
-	bool adapt_success;	// 是否成功适配内核, true 成功适配，false 适配失败
-	uint32_t data_limit_max;     // The maximum amount of data returned to the user-reader
+	volatile enum tracer_state state;	// 追踪器状态（Tracker status）
+	bool adapt_success;			// 是否成功适配内核, true 成功适配，false 适配失败
+	uint32_t data_limit_max;		// The maximum amount of data returned to the user-reader
 };
 
 #define EXTRA_TYPE_SERVER 0

--- a/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
+++ b/agent/src/ebpf_dispatcher/ebpf_dispatcher.rs
@@ -434,8 +434,7 @@ impl EbpfCollector {
                 if retry_count >= RETRY_MAX {
                     error!(
                         "The tracer_start() error. Kernel offset adapt failed. \
-                            Use the command 'uname -r' to obtain detailed kernel version \
-                            information, and provide the operating system name and the \
+                            Provide the operating system name and the \
                             'kernel-devel' package for developers to adapt."
                     );
                 }


### PR DESCRIPTION
tracer_hooks_detach() and tracer_hooks_attach() will become terrible when the number of probes is very large. Because we have to spend a long time waiting for it to complete, this is not a good way, we hope that calling socket_tracer_stop() or socket_tracer_start() will not block the execution of subsequent tasks.

In order to solve this problem, we use a global variable(`probes_act`) to hold the latest attach/detach behavior, it be executed later by another thread, so that the current thread will not be blocked.

It also avoids the problem that when rust calls the tracer start interface to start tracer, the status of the tracer has not been transitioned (the attach/detach action from the last probes has not yet completed), causing the tracer start invalidate in current operation.



### This PR is for:

- Agent


#### Affected branches
- main
- v6.1

#### Checklist
- [ ] Added unit test.
